### PR TITLE
Add /broadcast and /inbox slash commands

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -13,7 +13,9 @@
 
 🇬🇧 [English version](./README.md)
 
-Quand tu lances plusieurs sessions Claude Code sur le même dépôt, elles ne se voient pas entre elles. Elles se marchent dessus sur la CI, poussent par-dessus les commits des autres, ou refont le même travail. `claude-presence` est un petit serveur MCP qui donne à chaque session une vue des autres — plus des verrous consultatifs sur les ressources partagées (CI, base de staging, ports, tout ce que tu nommes).
+Quand tu lances plusieurs sessions Claude Code sur le même dépôt, elles ne se voient pas entre elles. Elles se marchent dessus sur la CI, poussent par-dessus les commits des autres, ou refont le même travail. `claude-presence` est un petit serveur MCP qui donne à chaque session une vue des autres, plus des verrous consultatifs sur les ressources partagées (CI, base de staging, ports, tout ce que tu nommes).
+
+> **Modèle mental.** Les sessions ne se parlent pas directement : chaque session Claude Code est un processus isolé. `claude-presence` leur fournit un tableau d'affichage partagé : chaque session voit qui d'autre travaille, quelles ressources sont verrouillées, et peut poster de courts messages que les autres liront quand elles feront leur check. C'est une couche de coordination légère, pas un pont de messagerie instantanée.
 
 **Le périmètre est volontairement restreint.** Présence + verrous sur ressources + boîte aux lettres courte. Pas d'intégration git, pas d'orchestration de tâches, pas d'UI web. Si tu veux plus, regarde [mcp_agent_mail](https://github.com/Dicklesworthstone/mcp_agent_mail).
 
@@ -163,9 +165,11 @@ Sans cérémonie. Tu tapes :
 | Commande | Ce qu'elle fait |
 |---|---|
 | `/register [intention]` | Enregistre la session avec une intention optionnelle (branche et cwd détectés automatiquement). |
+| `/presence` | Montre les autres sessions et les verrous actifs sur ce projet. |
 | `/claim <ressource> [raison]` | Réserve un verrou de ressource nommée. Si occupée, montre le détenteur au lieu de poursuivre. |
 | `/release <ressource>` | Libère un verrou que tu détiens. |
-| `/presence` | Montre les autres sessions et les verrous actifs sur ce projet. |
+| `/broadcast <message>` | Poste un court message dans la boîte du projet. Les autres sessions le verront à leur prochain `/inbox`. |
+| `/inbox [all\|unread]` | Lit les messages des autres sessions. Par défaut : non lus uniquement. |
 
 ### Exemple de flux
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 
 🇫🇷 [Version française](./README.fr.md)
 
-When you run multiple Claude Code sessions on the same repo, they don't know about each other. They step on each other's CI runs, push over each other, or duplicate work. `claude-presence` is a small MCP server that gives each session a view of the others — plus advisory locks on shared resources (CI, staging DB, ports, whatever you name).
+When you run multiple Claude Code sessions on the same repo, they don't know about each other. They step on each other's CI runs, push over each other, or duplicate work. `claude-presence` is a small MCP server that gives each session a view of the others, plus advisory locks on shared resources (CI, staging DB, ports, whatever you name).
+
+> **Mental model.** Sessions don't talk directly — each Claude Code session is an isolated process. `claude-presence` gives them a shared bulletin board: each session sees who else is working, what resources are claimed, and can post short messages that others will read when they check in. Think of it as a lightweight coordination layer, not a chat bridge.
 
 **Scope is deliberately small.** Presence + resource locks + a broadcast inbox. No git integration, no task orchestration, no web UI. If you need more, look at [mcp_agent_mail](https://github.com/Dicklesworthstone/mcp_agent_mail).
 
@@ -163,9 +165,11 @@ No ceremony. Just type:
 | Command | What it does |
 |---|---|
 | `/register [intent]` | Register this session with optional intent (branch + cwd auto-detected). |
+| `/presence` | Show other sessions + active locks on this project. |
 | `/claim <resource> [reason]` | Claim a named resource lock. If busy, shows the holder instead of proceeding. |
 | `/release <resource>` | Release a lock you hold. |
-| `/presence` | Show other sessions + active locks on this project. |
+| `/broadcast <message>` | Post a short message to the project inbox. Other sessions see it on their next `/inbox`. |
+| `/inbox [all\|unread]` | Read messages from other sessions. Default: unread only. |
 
 ### Example workflow
 

--- a/commands/broadcast.md
+++ b/commands/broadcast.md
@@ -1,0 +1,19 @@
+---
+description: Post a short message to the project-wide inbox so other Claude Code sessions on this project can see it.
+argument-hint: <message>
+---
+
+Call the `claude-presence` MCP `broadcast` tool.
+
+Use `$ARGUMENTS` as the `message`. If `$ARGUMENTS` is empty, ask the user what message to post.
+
+Required args for the tool:
+- `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first, then retry.
+- `project`: the project's absolute path.
+- `from_branch`: the current git branch if available (`git rev-parse --abbrev-ref HEAD`); omit if not a git repo.
+- `message`: the full `$ARGUMENTS` string.
+- `tags`: optional, only set if the user's message clearly starts with a category like "warning:", "heads-up:", "ci:" etc.
+
+After posting, confirm briefly (1 line) with the message id and a reminder that other sessions will see it on their next `/inbox` call or `/presence`.
+
+Keep messages short. This is a bulletin board, not chat.

--- a/commands/inbox.md
+++ b/commands/inbox.md
@@ -1,0 +1,21 @@
+---
+description: Read broadcast messages posted by other Claude Code sessions on this project.
+argument-hint: [all|unread]
+---
+
+Call the `claude-presence` MCP `read_inbox` tool.
+
+Parse `$ARGUMENTS`:
+- If `all`, call with `unread_only: false` to show the full history (last 50 messages).
+- If `unread` or empty (default), call with `unread_only: true` to show only messages you haven't read yet.
+
+Required args:
+- `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first, then retry.
+- `project`: the project's absolute path.
+
+Present each message as:
+- `[time ago] from-session (branch): message`
+
+If a message has `tags`, prepend them in brackets. If there are no messages, say so plainly (`No new messages` for unread, `No messages yet` for all).
+
+After displaying, messages returned with `unread_only: true` are automatically marked as read by the tool — don't warn the user, just show them.


### PR DESCRIPTION
## Summary

Adds the two missing slash commands so that sessions can actually communicate through the bulletin board, not just observe each other.

## Why

Real-world testing of v0.1 revealed a gap. When a user runs `/presence` and sees another session, the natural next question is "how do I talk to it?". The `broadcast` and `read_inbox` MCP tools already existed, but using them required typing a full natural-language request every time — which defeats the point of having slash commands for everything else.

## What changes

**New slash commands:**
- `/broadcast <message>` — post a short message to the project inbox
- `/inbox [all|unread]` — read messages (defaults to unread only)

**Clarified mental model** in both READMEs with a call-out block:
> Sessions don't talk directly — each Claude Code session is an isolated process. `claude-presence` gives them a shared bulletin board: each session sees who else is working, what resources are claimed, and can post short messages that others will read when they check in.

**Reordered the slash commands table** to match typical use order:

| Before | After |
|---|---|
| register → claim → release → presence | register → presence → claim → release → broadcast → inbox |

## Design notes

Message delivery is **pull-based**: the target session sees the broadcast on its next `/inbox` or `/presence` call. No push notifications, no direct session-to-session channel. This matches the "zero daemon, zero network" design principle — sessions remain fully isolated at the OS level, they just share a SQLite file.

## Test plan

- [x] Local tests still pass (25/25)
- [ ] CI matrix (6 jobs) passes on this PR
- [x] Tried `/broadcast` and `/inbox` in a local session
