### PR TITLE
v0.1.1 — fix rough edges from real-world testing

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -34,6 +34,7 @@ Quand tu lances plusieurs sessions Claude Code sur le même dépôt, elles ne se
 - [CLI](#cli)
 - [Dépannage](#dépannage)
 - [Comparaison](#comparaison)
+- [Sécurité et modèle de confiance](#sécurité-et-modèle-de-confiance)
 - [Stockage](#stockage)
 - [Développement](#développement)
 - [Statut](#statut)
@@ -78,7 +79,7 @@ C'est toute la boucle. Tout le reste ci-dessous, c'est du détail.
 - **Commandes slash** — `/register`, `/claim`, `/release`, `/presence` (sans cérémonie de frappe)
 - **CLI** — `claude-presence status` montre les sessions actives hors Claude Code
 - **Zéro démon** — adossé à SQLite, sans port, sans processus en arrière-plan
-- **Nettoyage par TTL** — les sessions mortes (pas de heartbeat pendant 2 min) sont purgées automatiquement
+- **Nettoyage par TTL** — les sessions mortes (pas de heartbeat pendant 10 min) sont purgées automatiquement
 
 ## Installation
 
@@ -305,7 +306,7 @@ Les commandes slash sont chargées au démarrage de session. Redémarre Claude C
 `claude-presence` ne s'enregistre pas automatiquement — tu dois appeler `/register` une fois par session. C'est volontaire : les sessions restent explicites et identifiables.
 
 **Un verrou est bloqué parce qu'une session a crashé.**
-Les sessions mortes sont purgées après 2 min (pas de heartbeat). Tu peux forcer le nettoyage immédiat avec `claude-presence clear`, ou forcer la libération d'un verrou spécifique via l'outil MCP `resource_release` avec `force: true`.
+Les sessions mortes sont purgées après 10 min (pas de heartbeat). Tu peux forcer le nettoyage immédiat avec `claude-presence clear`, ou forcer la libération d'un verrou spécifique via l'outil MCP `resource_release` avec `force: true`.
 
 **Les hooks semblent casser ma config GitKraken / un hook maison.**
 Va voir [Cohabitation avec des hooks existants](#cohabitation-avec-des-hooks-existants). Chaque événement a un tableau de hooks ; ajoute le tien sans retirer les autres.
@@ -324,6 +325,18 @@ Va voir [Cohabitation avec des hooks existants](#cohabitation-avec-des-hooks-exi
 
 Choisis `claude-presence` si tu veux quelque chose de petit et focalisé sur "que mes sessions ne se marchent pas dessus". Choisis `mcp_agent_mail` si tu veux des flux agent-à-agent riches.
 
+## Sécurité et modèle de confiance
+
+`claude-presence` est conçu pour **des sessions locales coopératives sur une seule machine de développeur**, pas pour un usage multi-locataire adversarial. Concrètement :
+
+- La base SQLite vit dans ton répertoire home et n'est joignable que par les processus qui tournent sous ton utilisateur.
+- Les `session_id` et champs `from_session` sont **auto-déclarés** — le serveur ne les authentifie pas. Un processus local bogué ou malveillant pourrait s'enregistrer sous n'importe quel ID ou poster des broadcasts en se faisant passer pour une autre session.
+- Les verrous sur ressources sont **consultatifs**, pas imposés. Une session peut ignorer un verrou détenu et pousser quand même. La valeur vient de l'accord tacite : toutes les sessions vérifient avant d'agir.
+
+C'est acceptable pour l'usage prévu (tes propres sessions Claude Code parallèles qui coopèrent) et explicitement pas acceptable pour exécuter du code non-fiable sur la même machine. Si tu as besoin d'identité cryptographique ou d'enforcement côté serveur, ce n'est pas le bon outil.
+
+Voir [#1](https://github.com/garniergeorges/claude-presence/issues) pour suivre les pistes de durcissement des prochaines versions (p. ex. dériver `from_session` depuis le contexte de connexion MCP au lieu de l'accepter en argument).
+
 ## Stockage
 
 Les données vivent dans `~/.claude-presence/state.db` (SQLite, mode WAL). Rien n'est envoyé ailleurs.
@@ -331,7 +344,7 @@ Les données vivent dans `~/.claude-presence/state.db` (SQLite, mode WAL). Rien 
 Pour changer le chemin : `CLAUDE_PRESENCE_DB=/chemin/personnalisé.db`.
 
 Rétention :
-- **Sessions** : purgées après 2 min sans heartbeat.
+- **Sessions** : purgées après 10 min sans heartbeat.
 - **Verrous** : purgés à expiration du TTL (10 min par défaut, configurable par claim, max 24 h).
 - **Boîte aux lettres** : purgée après 24 h.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ When you run multiple Claude Code sessions on the same repo, they don't know abo
 - [CLI](#cli)
 - [Troubleshooting](#troubleshooting)
 - [How it compares](#how-it-compares)
+- [Security & trust model](#security--trust-model)
 - [Storage](#storage)
 - [Development](#development)
 - [Status](#status)
@@ -78,7 +79,7 @@ That's the whole loop. Everything below is detail.
 - **Slash commands** — `/register`, `/claim`, `/release`, `/presence` (no typing ceremony)
 - **CLI** — `claude-presence status` shows active sessions outside Claude Code
 - **Zero daemon** — SQLite-backed, no port, no background process
-- **TTL-based cleanup** — dead sessions (no heartbeat for 2 min) are removed automatically
+- **TTL-based cleanup** — dead sessions (no heartbeat for 10 min) are removed automatically
 
 ## Install
 
@@ -305,7 +306,7 @@ Slash commands are loaded at session start. Restart Claude Code after `cp comman
 `claude-presence` doesn't auto-register — you must call `/register` once per session. This is deliberate: sessions stay explicit and identifiable.
 
 **A lock is stuck because a session crashed.**
-Dead sessions are pruned after 2 min (no heartbeat). You can force-clean immediately with `claude-presence clear`, or force-release a specific lock with the `resource_release` MCP tool passing `force: true`.
+Dead sessions are pruned after 10 min (no heartbeat). You can force-clean immediately with `claude-presence clear`, or force-release a specific lock with the `resource_release` MCP tool passing `force: true`.
 
 **Hooks seem to break my existing GitKraken / custom hook setup.**
 See [Merging with existing hooks](#merging-with-existing-hooks). Each event holds an array of hooks; add yours without removing others.
@@ -324,6 +325,18 @@ See [Merging with existing hooks](#merging-with-existing-hooks). Each event hold
 
 Pick `claude-presence` if you want something small and focused on "don't let my sessions step on each other". Pick `mcp_agent_mail` if you want rich agent-to-agent workflows.
 
+## Security & trust model
+
+`claude-presence` is designed for **cooperating local sessions on a single developer machine**, not for adversarial multi-tenant use. Concretely:
+
+- The SQLite database lives in your home directory and is only reachable by processes running as you.
+- Session IDs and `from_session` fields are **self-declared** — the server doesn't authenticate them. A buggy or malicious local process could register as any ID or post broadcasts claiming to be another session.
+- Resource locks are **advisory**, not enforced. A session can ignore a held lock and push anyway. The value comes from every session agreeing to check first.
+
+This is fine for the intended use case (your own parallel Claude Code sessions cooperating) and explicitly not fine for running untrusted code on the same box. If you need cryptographic identity or server-side enforcement, this isn't the right tool.
+
+See [#1](https://github.com/garniergeorges/claude-presence/issues) track hardening ideas for future versions (e.g. deriving `from_session` from the MCP connection context instead of accepting it as an argument).
+
 ## Storage
 
 Data lives in `~/.claude-presence/state.db` (SQLite, WAL mode). Nothing is sent anywhere.
@@ -331,7 +344,7 @@ Data lives in `~/.claude-presence/state.db` (SQLite, WAL mode). Nothing is sent 
 Override the path with `CLAUDE_PRESENCE_DB=/custom/path.db`.
 
 Retention:
-- **Sessions**: pruned after 2 min without heartbeat.
+- **Sessions**: pruned after 10 min without heartbeat.
 - **Locks**: pruned when their TTL expires (default 10 min, configurable per-claim, max 24 h).
 - **Inbox**: pruned after 24 h.
 

--- a/commands/inbox.md
+++ b/commands/inbox.md
@@ -18,4 +18,6 @@ Present each message as:
 
 If a message has `tags`, prepend them in brackets. If there are no messages, say so plainly (`No new messages` for unread, `No messages yet` for all).
 
-After displaying, messages returned with `unread_only: true` are automatically marked as read by the tool — don't warn the user, just show them.
+The tool response includes `unread_total` (count of unread at the moment of the call, before marking-as-read) and `total` (count of all messages from other sessions on this project). Use these to give the user context, e.g. "3 new messages, 12 total on this project" — especially when the user re-runs `/inbox` rapidly and wonders if they missed something.
+
+After displaying, messages returned with unread_only are automatically marked as read by the tool — don't warn the user, just show them.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-presence",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Minimal MCP server for inter-session coordination between parallel Claude Code instances: presence registry, resource locks, broadcast inbox.",
   "type": "module",
   "bin": {

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -20,6 +20,14 @@ export interface ClaimResult {
   ok: boolean;
   lock?: ResourceLockRow;
   held_by?: ResourceLockRow;
+  session_recreated?: boolean;
+}
+
+export interface HeartbeatResult {
+  ok: boolean;
+  reason?: "session_not_found";
+  advice?: string;
+  recreated?: boolean;
 }
 
 export class Repository {
@@ -84,16 +92,34 @@ export class Repository {
     return this.getSession(input.id)!;
   }
 
-  heartbeat(sessionId: string): boolean {
+  heartbeat(
+    sessionId: string,
+    recreateWith?: RegisterSessionInput,
+  ): HeartbeatResult {
     const stmt = this.db.prepare(
       "UPDATE sessions SET last_heartbeat = ? WHERE id = ?",
     );
-    return stmt.run(this.now(), sessionId).changes > 0;
+    const updated = stmt.run(this.now(), sessionId).changes > 0;
+    if (updated) return { ok: true };
+
+    if (recreateWith && recreateWith.id === sessionId) {
+      this.registerSession(recreateWith);
+      return { ok: true, recreated: true };
+    }
+    return {
+      ok: false,
+      reason: "session_not_found",
+      advice:
+        "Session was pruned (TTL expired) or never registered. Call session_register to re-create it.",
+    };
   }
 
-  unregisterSession(sessionId: string): boolean {
-    const stmt = this.db.prepare("DELETE FROM sessions WHERE id = ?");
-    return stmt.run(sessionId).changes > 0;
+  unregisterSession(sessionId: string): { removed: boolean; reason?: string } {
+    const changes = this.db
+      .prepare("DELETE FROM sessions WHERE id = ?")
+      .run(sessionId).changes;
+    if (changes > 0) return { removed: true };
+    return { removed: false, reason: "session_not_found" };
   }
 
   getSession(sessionId: string): SessionRow | undefined {
@@ -129,6 +155,16 @@ export class Repository {
     const ttlMs = (input.ttl_seconds ?? LOCK_DEFAULT_TTL_MS / 1000) * 1000;
     const expires_at = now + ttlMs;
 
+    let sessionRecreated = false;
+    if (!this.getSession(input.session_id)) {
+      this.registerSession({
+        id: input.session_id,
+        project: input.project,
+        branch: input.branch ?? null,
+      });
+      sessionRecreated = true;
+    }
+
     const existing = this.db
       .prepare(
         "SELECT * FROM resource_locks WHERE project = ? AND resource = ?",
@@ -136,7 +172,11 @@ export class Repository {
       .get(input.project, input.resource) as ResourceLockRow | undefined;
 
     if (existing && existing.session_id !== input.session_id) {
-      return { ok: false, held_by: existing };
+      return {
+        ok: false,
+        held_by: existing,
+        session_recreated: sessionRecreated || undefined,
+      };
     }
 
     const stmt = this.db.prepare(`
@@ -165,7 +205,11 @@ export class Repository {
       )
       .get(input.project, input.resource) as ResourceLockRow;
 
-    return { ok: true, lock };
+    return {
+      ok: true,
+      lock,
+      session_recreated: sessionRecreated || undefined,
+    };
   }
 
   releaseResource(input: {
@@ -237,7 +281,7 @@ export class Repository {
     session_id: string;
     unread_only?: boolean;
     limit?: number;
-  }): InboxRow[] {
+  }): { messages: InboxRow[]; unread_total: number; total: number } {
     this.pruneOldInbox();
     const limit = input.limit ?? 50;
     let rows: InboxRow[];
@@ -273,6 +317,25 @@ export class Repository {
         .all(input.project, input.session_id, limit) as InboxRow[];
     }
 
+    // Counts are computed BEFORE marking as read, so the caller sees
+    // how many unread messages existed at the moment of the call.
+    const unreadCountRow = this.db
+      .prepare(
+        `
+        SELECT COUNT(*) AS n FROM inbox i
+        LEFT JOIN inbox_reads r
+          ON r.message_id = i.id AND r.session_id = ?
+        WHERE i.project = ? AND r.message_id IS NULL AND i.from_session != ?
+      `,
+      )
+      .get(input.session_id, input.project, input.session_id) as { n: number };
+
+    const totalCountRow = this.db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM inbox WHERE project = ? AND from_session != ?`,
+      )
+      .get(input.project, input.session_id) as { n: number };
+
     if (rows.length > 0) {
       const markStmt = this.db.prepare(
         "INSERT OR IGNORE INTO inbox_reads (session_id, message_id, read_at) VALUES (?, ?, ?)",
@@ -284,6 +347,10 @@ export class Repository {
       tx(rows);
     }
 
-    return rows;
+    return {
+      messages: rows,
+      unread_total: unreadCountRow.n,
+      total: totalCountRow.n,
+    };
   }
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -49,6 +49,6 @@ CREATE TABLE IF NOT EXISTS inbox_reads (
 );
 `;
 
-export const SESSION_TTL_MS = 2 * 60 * 1000;
+export const SESSION_TTL_MS = 10 * 60 * 1000;
 export const LOCK_DEFAULT_TTL_MS = 10 * 60 * 1000;
 export const INBOX_RETENTION_MS = 24 * 60 * 60 * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { inboxTools } from "./tools/inbox.js";
 import type { McpTool } from "./tools/helpers.js";
 
 const PACKAGE_NAME = "claude-presence";
-const PACKAGE_VERSION = "0.1.0";
+const PACKAGE_VERSION = "0.1.1";
 
 const SERVER_INSTRUCTIONS = `
 This server coordinates multiple Claude Code sessions running in parallel on the same machine.

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -46,15 +46,17 @@ export function inboxTools(repo: Repository): McpTool[] {
         limit: z.number().int().positive().max(200).optional().default(50),
       },
       handler: async (args) => {
-        const rows = repo.readInbox({
+        const result = repo.readInbox({
           project: args.project,
           session_id: args.session_id,
           unread_only: args.unread_only,
           limit: args.limit,
         });
         return {
-          count: rows.length,
-          messages: rows.map(formatInbox),
+          count: result.messages.length,
+          unread_total: result.unread_total,
+          total: result.total,
+          messages: result.messages.map(formatInbox),
         };
       },
     },

--- a/src/tools/locks.ts
+++ b/src/tools/locks.ts
@@ -54,13 +54,19 @@ export function lockTools(repo: Repository): McpTool[] {
                   intent: heldBySession.intent,
                 }
               : null,
+            ...(result.session_recreated
+              ? { session_recreated: true }
+              : {}),
           };
         }
 
         return {
           ok: true,
-          message: `Lock acquired on '${args.resource}'. Remember to resource_release when done.`,
+          message: result.session_recreated
+            ? `Lock acquired on '${args.resource}'. Note: your session had been pruned (TTL expired) and was silently re-registered — consider keeping a regular session_heartbeat.`
+            : `Lock acquired on '${args.resource}'. Remember to resource_release when done.`,
           lock: formatLock(result.lock!),
+          ...(result.session_recreated ? { session_recreated: true } : {}),
         };
       },
     },

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -54,13 +54,29 @@ export function presenceTools(repo: Repository): McpTool[] {
     {
       name: "session_heartbeat",
       description:
-        "Refresh this session's last-seen timestamp. Call periodically (at most every 30s) so the session isn't pruned as dead (TTL: 2 min).",
+        "Refresh this session's last-seen timestamp. Call periodically (every minute or two) so the session isn't pruned as dead (TTL: 10 min). If the session was already pruned, supply the optional recreate_* fields to have the server silently re-register it.",
       inputShape: {
         session_id: z.string().min(1),
+        recreate_project: z
+          .string()
+          .optional()
+          .describe(
+            "If provided along with recreate_* fields, auto-recreate the session when it has been pruned.",
+          ),
+        recreate_branch: z.string().optional(),
+        recreate_intent: z.string().optional(),
       },
       handler: async (args) => {
-        const ok = repo.heartbeat(args.session_id);
-        return { ok, at: new Date().toISOString() };
+        const recreateWith = args.recreate_project
+          ? {
+              id: args.session_id,
+              project: args.recreate_project,
+              branch: args.recreate_branch ?? null,
+              intent: args.recreate_intent ?? null,
+            }
+          : undefined;
+        const result = repo.heartbeat(args.session_id, recreateWith);
+        return { ...result, at: new Date().toISOString() };
       },
     },
     {
@@ -71,8 +87,7 @@ export function presenceTools(repo: Repository): McpTool[] {
         session_id: z.string().min(1),
       },
       handler: async (args) => {
-        const removed = repo.unregisterSession(args.session_id);
-        return { removed };
+        return repo.unregisterSession(args.session_id);
       },
     },
     {

--- a/tests/inbox.test.ts
+++ b/tests/inbox.test.ts
@@ -21,22 +21,24 @@ describe("Repository — broadcast inbox", () => {
       from_session: "sess-A",
       message: "refactored auth module",
     });
-    const fromBPov = repo.readInbox({
+    const res = repo.readInbox({
       project: "/repo",
       session_id: "sess-B",
     });
-    expect(fromBPov).toHaveLength(1);
-    expect(fromBPov[0].from_session).toBe("sess-A");
-    expect(fromBPov[0].message).toBe("refactored auth module");
+    expect(res.messages).toHaveLength(1);
+    expect(res.messages[0].from_session).toBe("sess-A");
+    expect(res.messages[0].message).toBe("refactored auth module");
+    expect(res.total).toBe(1);
   });
 
   it("excludes the author's own messages", () => {
     repo.broadcast({ project: "/repo", from_session: "sess-A", message: "m1" });
-    const selfPov = repo.readInbox({
+    const res = repo.readInbox({
       project: "/repo",
       session_id: "sess-A",
     });
-    expect(selfPov).toHaveLength(0);
+    expect(res.messages).toHaveLength(0);
+    expect(res.total).toBe(0);
   });
 
   it("unread_only: true hides already-read messages", () => {
@@ -46,14 +48,16 @@ describe("Repository — broadcast inbox", () => {
       session_id: "sess-B",
       unread_only: true,
     });
-    expect(firstRead).toHaveLength(1);
+    expect(firstRead.messages).toHaveLength(1);
+    expect(firstRead.unread_total).toBe(1);
 
     const secondRead = repo.readInbox({
       project: "/repo",
       session_id: "sess-B",
       unread_only: true,
     });
-    expect(secondRead).toHaveLength(0);
+    expect(secondRead.messages).toHaveLength(0);
+    expect(secondRead.unread_total).toBe(0);
   });
 
   it("unread_only: false returns the full history", () => {
@@ -64,7 +68,8 @@ describe("Repository — broadcast inbox", () => {
       session_id: "sess-B",
       unread_only: false,
     });
-    expect(all).toHaveLength(1);
+    expect(all.messages).toHaveLength(1);
+    expect(all.total).toBe(1);
   });
 
   it("scopes inbox per project", () => {
@@ -73,8 +78,8 @@ describe("Repository — broadcast inbox", () => {
     repo.broadcast({ project: "/other", from_session: "sess-C", message: "there" });
 
     const repoInbox = repo.readInbox({ project: "/repo", session_id: "sess-B" });
-    expect(repoInbox).toHaveLength(1);
-    expect(repoInbox[0].message).toBe("here");
+    expect(repoInbox.messages).toHaveLength(1);
+    expect(repoInbox.messages[0].message).toBe("here");
   });
 
   it("preserves tags as an array when provided", () => {
@@ -84,7 +89,23 @@ describe("Repository — broadcast inbox", () => {
       message: "heads up",
       tags: ["warning", "ci"],
     });
-    const msgs = repo.readInbox({ project: "/repo", session_id: "sess-B" });
-    expect(msgs[0].tags).toBe('["warning","ci"]');
+    const res = repo.readInbox({ project: "/repo", session_id: "sess-B" });
+    expect(res.messages[0].tags).toBe('["warning","ci"]');
+  });
+
+  it("reports unread_total even when no messages are returned (already read)", () => {
+    repo.broadcast({ project: "/repo", from_session: "sess-A", message: "m1" });
+    repo.readInbox({ project: "/repo", session_id: "sess-B", unread_only: true });
+
+    // Second call with unread_only: empty messages, unread_total=0,
+    // but total=1 so caller can see history exists
+    const second = repo.readInbox({
+      project: "/repo",
+      session_id: "sess-B",
+      unread_only: true,
+    });
+    expect(second.messages).toHaveLength(0);
+    expect(second.unread_total).toBe(0);
+    expect(second.total).toBe(1);
   });
 });

--- a/tests/locks.test.ts
+++ b/tests/locks.test.ts
@@ -127,4 +127,28 @@ describe("Repository — resource locks", () => {
     repo.unregisterSession("sess-A");
     expect(repo.listLocks("/repo")).toHaveLength(0);
   });
+
+  it("claimResource auto-recreates a pruned session instead of failing with FK error", () => {
+    // Session does NOT exist beforehand (simulating pruning)
+    const r = repo.claimResource({
+      resource: "ci",
+      project: "/repo",
+      session_id: "ghost-session",
+      branch: "feat/recreate",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.session_recreated).toBe(true);
+    expect(repo.getSession("ghost-session")).toBeDefined();
+    expect(repo.getSession("ghost-session")!.branch).toBe("feat/recreate");
+  });
+
+  it("claimResource does NOT set session_recreated when session already exists", () => {
+    const r = repo.claimResource({
+      resource: "ci",
+      project: "/repo",
+      session_id: "sess-A",
+    });
+    expect(r.ok).toBe(true);
+    expect(r.session_recreated).toBeUndefined();
+  });
 });

--- a/tests/presence.test.ts
+++ b/tests/presence.test.ts
@@ -58,22 +58,40 @@ describe("Repository — presence", () => {
     const before = repo.getSession("sess-A")!.last_heartbeat;
 
     vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
-    const ok = repo.heartbeat("sess-A");
-    expect(ok).toBe(true);
+    const res = repo.heartbeat("sess-A");
+    expect(res.ok).toBe(true);
+    expect(res.recreated).toBeUndefined();
 
     const after = repo.getSession("sess-A")!.last_heartbeat;
     expect(after).toBeGreaterThan(before);
   });
 
-  it("heartbeat returns false for unknown session", () => {
-    expect(repo.heartbeat("nope")).toBe(false);
+  it("heartbeat on unknown session returns explicit reason + advice", () => {
+    const res = repo.heartbeat("nope");
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("session_not_found");
+    expect(res.advice).toMatch(/session_register/);
+  });
+
+  it("heartbeat can recreate a pruned session when recreateWith is supplied", () => {
+    const res = repo.heartbeat("sess-X", {
+      id: "sess-X",
+      project: "/repo",
+      branch: "feat/x",
+    });
+    expect(res.ok).toBe(true);
+    expect(res.recreated).toBe(true);
+    expect(repo.getSession("sess-X")).toBeDefined();
   });
 
   it("unregisterSession removes the row", () => {
     repo.registerSession({ id: "sess-A", project: "/repo" });
-    expect(repo.unregisterSession("sess-A")).toBe(true);
+    expect(repo.unregisterSession("sess-A")).toEqual({ removed: true });
     expect(repo.listSessions("/repo")).toHaveLength(0);
-    expect(repo.unregisterSession("sess-A")).toBe(false);
+    expect(repo.unregisterSession("sess-A")).toEqual({
+      removed: false,
+      reason: "session_not_found",
+    });
   });
 
   it("prunes dead sessions past the TTL when listing", () => {


### PR DESCRIPTION
## Summary

Fixes six rough edges surfaced during real-world testing with two parallel Claude Code sessions dialoguing via broadcast + heartbeat loops. Bumps to **v0.1.1**.

## Context

Two sessions ran side-by-side for ~20 min with a cron-based "heartbeat + check inbox" loop every minute. They exchanged questions/answers about their own setup and flagged concrete issues they ran into — see the 6 fixes below.

## Fixes

### 1. Session TTL: 2 min → 10 min

`SESSION_TTL_MS` was too aggressive without an auto-heartbeat mechanism. Two idle sessions got pruned simultaneously, and the next `resource_claim` failed with a cryptic `FOREIGN KEY constraint failed`.

### 2. `resource_claim` auto-recreates a pruned session

Instead of failing with an FK error when the session no longer exists, the claim now silently re-registers the session (with the same id, project, branch from the claim payload) and returns a `session_recreated: true` flag so Claude can tell the user.

### 3. `session_heartbeat` returns structured errors + can recreate

Was: `{ ok: false }` on unknown session — totally opaque.
Now: `{ ok: false, reason: "session_not_found", advice: "Session was pruned (TTL expired)..." }`. Accepts optional `recreate_project/branch/intent` to re-register on the same call.

### 4. `session_unregister` also returns explicit reasons

`{ removed: true }` vs `{ removed: false, reason: "session_not_found" }`.

### 5. `read_inbox` exposes unread/total counters

Was: just returned the message array. If a session rapidly re-read, it saw an empty list and wondered if messages had been missed.
Now: `{ messages, unread_total, total }`. Counters are computed **before** marking-as-read, so the caller knows exactly how many unread existed at call time and how many total messages are in the project bulletin board.

`/inbox` slash command updated to surface these in its output.

### 6. New "Security & trust model" section in READMEs

One session noticed that `from_session` is user-controlled in a `broadcast`, which technically allows impersonation within the same machine. This is fine for the cooperative-local-sessions use case but worth documenting. Both READMEs now have a dedicated section clarifying:

- Cooperating local sessions only
- Self-declared session IDs (no auth)
- Advisory locks (not enforced)
- Pointer to future hardening (deriving `from_session` from MCP connection context)

## Tests

- **29 tests total** (was 25), all passing in ~1.3 s locally
- 4 new tests:
  - `heartbeat` returns explicit reason + advice on unknown session
  - `heartbeat` auto-recreates with `recreateWith` payload
  - `claimResource` auto-recreates pruned session without FK error
  - `readInbox` reports `unread_total` and `total` independently of returned messages

## Test plan

- [x] Local tests pass (29/29)
- [x] Build passes (`tsc`)
- [x] `package.json` and server version bumped to `0.1.1`
- [ ] CI matrix (6 jobs) passes on this PR
- [ ] After merge, tag `v0.1.1` and update GitHub release
