### PR TITLE
chore: gitignore .session-notes/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 coverage/
 .vscode/
 .idea/
+
+# Private session notes — never committed
+.session-notes/


### PR DESCRIPTION
Adds `.session-notes/` to `.gitignore` so private local notes never get committed. No production code impact.