### PR TITLE
chore: bump to 0.2.1 + npm install instructions

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -96,13 +96,25 @@ npm link       # expose claude-presence (CLI), claude-presence-mcp (stdio),
                # et claude-presence-server (HTTP, v0.2+) globalement
 ```
 
-### Depuis npm (quand publié)
+### Depuis npm
 
 ```bash
 npm install -g claude-presence
 ```
 
-Ou invoque via `npx` directement depuis `.mcp.json` — pas besoin d'install globale.
+Ou invoque via `npx` directement depuis `.mcp.json` — pas besoin d'install globale :
+
+```json
+{
+  "mcpServers": {
+    "claude-presence": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "claude-presence-mcp"]
+    }
+  }
+}
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,25 @@ npm link       # exposes claude-presence (CLI), claude-presence-mcp (stdio),
                # and claude-presence-server (HTTP, v0.2+) globally
 ```
 
-### From npm (when published)
+### From npm
 
 ```bash
 npm install -g claude-presence
 ```
 
-Or invoke via `npx` directly from `.mcp.json` — no global install needed.
+Or invoke via `npx` directly from `.mcp.json` — no global install needed:
+
+```json
+{
+  "mcpServers": {
+    "claude-presence": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "claude-presence-mcp"]
+    }
+  }
+}
+```
 
 ## Configure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-presence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-presence",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-presence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Minimal MCP server for inter-session coordination between parallel Claude Code instances: presence registry, resource locks, broadcast inbox.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Repository } from "./db/repository.js";
 import { registerAllTools } from "./tools/registry.js";
 
 const PACKAGE_NAME = "claude-presence";
-const PACKAGE_VERSION = "0.2.0";
+const PACKAGE_VERSION = "0.2.1";
 
 const SERVER_INSTRUCTIONS = `
 This server coordinates multiple Claude Code sessions running in parallel on the same machine.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,7 +11,7 @@ import { handleHealth } from "./health.js";
 import { log } from "./logger.js";
 
 const PACKAGE_NAME = "claude-presence";
-const PACKAGE_VERSION = "0.2.0";
+const PACKAGE_VERSION = "0.2.1";
 
 const DEFAULT_PORT = 3471;
 const DEFAULT_HOST = "127.0.0.1";


### PR DESCRIPTION
## Summary

Bumps the version to 0.2.1 and updates the install sections of both READMEs now that **claude-presence is live on npm** (https://www.npmjs.com/package/claude-presence).

## What changes

- `package.json`, `package-lock.json`, `src/index.ts`, `src/server/index.ts` → version 0.2.1
- README EN/FR: "From npm (when published)" → "From npm", with an npx-based `.mcp.json` snippet
- This release also bundles the session TTL fix from #16 (10 min → 7 days) which was merged but never tagged as a proper version.

## npm registry

- https://www.npmjs.com/package/claude-presence
- `npm install -g claude-presence` works
- `npx -y claude-presence-mcp` works for ad-hoc use

## Test plan

- [x] npm publish 0.2.1 succeeded (live on npmjs.com)
- [x] All 69 tests pass locally
- [ ] CI matrix (6 jobs) passes on this PR