### PR TITLE
fix: shorten session TTL from 7 days to 24 hours

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -81,7 +81,7 @@ C'est toute la boucle. Tout le reste ci-dessous, c'est du détail.
 - **CLI** — `claude-presence status` montre les sessions actives hors Claude Code
 - **Zéro démon (mode stdio)** — adossé à SQLite, sans port, sans processus en arrière-plan pour l'usage solo / mono-machine
 - **Mode équipe (v0.2+)** — serveur HTTP auto-hébergé optionnel avec auth bearer-token et RBAC pour coordonner plusieurs machines
-- **Nettoyage par TTL** — les sessions sans heartbeat depuis 7 jours sont purgées automatiquement
+- **Nettoyage par TTL** — les sessions sans heartbeat depuis 24 heures sont purgées automatiquement
 
 ## Installation
 
@@ -321,7 +321,7 @@ Les commandes slash sont chargées au démarrage de session. Redémarre Claude C
 `claude-presence` ne s'enregistre pas automatiquement — tu dois appeler `/register` une fois par session. C'est volontaire : les sessions restent explicites et identifiables.
 
 **Un verrou est bloqué parce qu'une session a crashé.**
-Les sessions sans heartbeat sont purgées après 7 jours. Tu peux forcer le nettoyage immédiat avec `claude-presence clear`, ou forcer la libération d'un verrou spécifique via l'outil MCP `resource_release` avec `force: true`.
+Les sessions sans heartbeat sont purgées après 24 heures. Tu peux forcer le nettoyage immédiat avec `claude-presence clear`, ou forcer la libération d'un verrou spécifique via l'outil MCP `resource_release` avec `force: true`.
 
 **Les hooks semblent casser ma config GitKraken / un hook maison.**
 Va voir [Cohabitation avec des hooks existants](#cohabitation-avec-des-hooks-existants). Chaque événement a un tableau de hooks ; ajoute le tien sans retirer les autres.
@@ -375,7 +375,7 @@ Tables :
 - `team_tokens`, `audit_log` — utilisées uniquement par `claude-presence-server` (mode équipe v0.2+)
 
 Rétention :
-- **Sessions** : purgées après 7 jours sans heartbeat.
+- **Sessions** : purgées après 24 heures sans heartbeat.
 - **Verrous** : purgés à expiration du TTL (10 min par défaut, configurable par claim, max 24 h).
 - **Boîte aux lettres** : purgée après 24 h.
 - **Audit log** : conservé indéfiniment ; à requêter et purger manuellement si besoin.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ That's the whole loop. Everything below is detail.
 - **CLI** — `claude-presence status` shows active sessions outside Claude Code
 - **Zero daemon (stdio mode)** — SQLite-backed, no port, no background process for solo / single-machine use
 - **Team mode (v0.2+)** — optional self-hosted HTTP server with bearer-token auth and RBAC for coordination across machines
-- **TTL-based cleanup** — sessions with no heartbeat for 7 days are removed automatically
+- **TTL-based cleanup** — sessions with no heartbeat for 24 hours are removed automatically
 
 ## Install
 
@@ -321,7 +321,7 @@ Slash commands are loaded at session start. Restart Claude Code after `cp comman
 `claude-presence` doesn't auto-register — you must call `/register` once per session. This is deliberate: sessions stay explicit and identifiable.
 
 **A lock is stuck because a session crashed.**
-Sessions with no heartbeat are pruned after 7 days. You can force-clean immediately with `claude-presence clear`, or force-release a specific lock with the `resource_release` MCP tool passing `force: true`.
+Sessions with no heartbeat are pruned after 24 hours. You can force-clean immediately with `claude-presence clear`, or force-release a specific lock with the `resource_release` MCP tool passing `force: true`.
 
 **Hooks seem to break my existing GitKraken / custom hook setup.**
 See [Merging with existing hooks](#merging-with-existing-hooks). Each event holds an array of hooks; add yours without removing others.
@@ -375,7 +375,7 @@ Tables:
 - `team_tokens`, `audit_log` — only used by `claude-presence-server` (team mode v0.2+)
 
 Retention:
-- **Sessions**: pruned after 7 days without heartbeat.
+- **Sessions**: pruned after 24 hours without heartbeat.
 - **Locks**: pruned when their TTL expires (default 10 min, configurable per-claim, max 24 h).
 - **Inbox**: pruned after 24 h.
 - **Audit log**: kept indefinitely; query and prune manually if needed.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -78,6 +78,6 @@ CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
 CREATE INDEX IF NOT EXISTS idx_audit_token ON audit_log(token_id);
 `;
 
-export const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 export const LOCK_DEFAULT_TTL_MS = 10 * 60 * 1000;
 export const INBOX_RETENTION_MS = 24 * 60 * 60 * 1000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ Before touching shared resources (CI, deploys, ports, staging DBs), try resource
 with a descriptive resource name. If ok=false, another session holds it — decide whether
 to wait, coordinate via broadcast, or ask the user.
 
-Sessions are kept for 7 days without a heartbeat. Call session_heartbeat
+Sessions are kept for 24 hours without a heartbeat. Call session_heartbeat
 occasionally if you want others to see this session as recently active,
 and session_unregister on clean exit.
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,7 +21,7 @@ This server coordinates Claude Code sessions across machines via HTTP MCP.
 
 At session start, call session_register with a stable session_id and project path.
 Before touching shared resources, call resource_claim. Sessions are
-kept for 7 days without a heartbeat. Data stored locally in SQLite.
+kept for 24 hours without a heartbeat. Data stored locally in SQLite.
 No telemetry, no cloud.
 `.trim();
 

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -54,7 +54,7 @@ export function presenceTools(repo: Repository): McpTool[] {
     {
       name: "session_heartbeat",
       description:
-        "Refresh this session's last-seen timestamp. Sessions are kept for 7 days without a heartbeat before being pruned, so periodic heartbeats are only required if you want to mark the session as recently active. If the session was already pruned, supply the optional recreate_* fields to have the server silently re-register it.",
+        "Refresh this session's last-seen timestamp. Sessions are kept for 24 hours without a heartbeat before being pruned, so periodic heartbeats are only required if you want to mark the session as recently active. If the session was already pruned, supply the optional recreate_* fields to have the server silently re-register it.",
       inputShape: {
         session_id: z.string().min(1),
         recreate_project: z
@@ -93,7 +93,7 @@ export function presenceTools(repo: Repository): McpTool[] {
     {
       name: "session_list",
       description:
-        "List active sessions. By default limited to the given project. Sessions with no heartbeat for 7 days are pruned automatically when the list is requested.",
+        "List active sessions. By default limited to the given project. Sessions with no heartbeat for 24 hours are pruned automatically when the list is requested.",
       inputShape: {
         project: z
           .string()


### PR DESCRIPTION
## Summary

- 7 days kept stale sessions visible in `/presence` and `session_list` long after the user had closed the related session.
- 24 hours is short enough to declutter the registry while still surviving overnight pauses.
- `SESSION_TTL_MS` is the only behavioral change; user-facing strings in both READMEs and the MCP server instructions are kept in sync.

## Test plan

- [x] `npm test` — 69/69 green locally
- [x] `grep -rn "7 days\|7 jours" src tests README.md README.fr.md docs` — no residual references
- [ ] CI green on Ubuntu + macOS × Node 18/20/22 (6 jobs)