### PR TITLE
feat: targeted notifications, priorities, and auto-surfacing

### DIFF
--- a/commands/broadcast.md
+++ b/commands/broadcast.md
@@ -1,19 +1,24 @@
 ---
-description: Post a short message to the project-wide inbox so other Claude Code sessions on this project can see it.
-argument-hint: <message>
+description: Post a message to the project inbox so other sessions on this project can see it. Supports targeting and priority.
+argument-hint: [--to <session>] [--priority info|warning|urgent] <message>
 ---
 
 Call the `claude-presence` MCP `broadcast` tool.
 
-Use `$ARGUMENTS` as the `message`. If `$ARGUMENTS` is empty, ask the user what message to post.
+Parse `$ARGUMENTS`:
+- If it begins with `--to <session-id>`, capture `to_session` and remove that prefix from the message.
+- If it begins with `--priority <info|warning|urgent>`, capture `priority` and remove that prefix.
+- Both flags may appear in any order; the rest is the `message`. If `message` is empty after parsing, ask the user what to post.
 
 Required args for the tool:
 - `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first, then retry.
 - `project`: the project's absolute path.
 - `from_branch`: the current git branch if available (`git rev-parse --abbrev-ref HEAD`); omit if not a git repo.
-- `message`: the full `$ARGUMENTS` string.
-- `tags`: optional, only set if the user's message clearly starts with a category like "warning:", "heads-up:", "ci:" etc.
+- `message`: the parsed message string.
+- `to_session`: only set if `--to` was passed.
+- `priority`: only set if `--priority` was passed (default `info` server-side).
+- `tags`: optional, only set if the message clearly starts with a category prefix like `ci:`, `refactor:`, etc.
 
-After posting, confirm briefly (1 line) with the message id and a reminder that other sessions will see it on their next `/inbox` call or `/presence`.
+After posting, confirm in one line: the message id, target (`→ <session>` or `→ all`), and priority. Remind the user that `warning` and `urgent` messages will appear automatically on the recipient's next prompt; `info` requires `/inbox`.
 
 Keep messages short. This is a bulletin board, not chat.

--- a/commands/inbox.md
+++ b/commands/inbox.md
@@ -1,23 +1,29 @@
 ---
-description: Read broadcast messages posted by other Claude Code sessions on this project.
-argument-hint: [all|unread]
+description: Read messages addressed to this session — direct messages and project-wide broadcasts.
+argument-hint: [all|unread] [--peek] [--min-priority info|warning|urgent]
 ---
 
 Call the `claude-presence` MCP `read_inbox` tool.
 
 Parse `$ARGUMENTS`:
-- If `all`, call with `unread_only: false` to show the full history (last 50 messages).
-- If `unread` or empty (default), call with `unread_only: true` to show only messages you haven't read yet.
+- If it contains `all`, call with `unread_only: false` to show the full history (last 50 messages).
+- Otherwise (or with `unread`), call with `unread_only: true`.
+- If it contains `--peek`, pass `peek: true` so the messages stay marked as unread.
+- If it contains `--min-priority <info|warning|urgent>`, pass `min_priority`.
 
 Required args:
-- `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first, then retry.
+- `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first.
 - `project`: the project's absolute path.
 
 Present each message as:
-- `[time ago] from-session (branch): message`
+- `[time ago] [priority] from <session> (branch) → <target>: message`
 
-If a message has `tags`, prepend them in brackets. If there are no messages, say so plainly (`No new messages` for unread, `No messages yet` for all).
+Where `<target>` is either `me` (direct message addressed to this session, i.e. `to_session = my session_id`) or `all` (project-wide broadcast). Hide the `[priority]` bracket when priority is `info`.
 
-The tool response includes `unread_total` (count of unread at the moment of the call, before marking-as-read) and `total` (count of all messages from other sessions on this project). Use these to give the user context, e.g. "3 new messages, 12 total on this project" — especially when the user re-runs `/inbox` rapidly and wonders if they missed something.
+If a message has `tags`, prepend them in brackets after priority.
 
-After displaying, messages returned with unread_only are automatically marked as read by the tool — don't warn the user, just show them.
+If there are no messages, say so plainly (`No new messages` for unread, `No messages yet` for all).
+
+The tool response includes `unread_total` (count at the moment of the call, before mark-as-read) and `total` (count of all visible messages on this project). Surface both, e.g. "3 new, 12 total" — especially when the user re-runs `/inbox` rapidly and wonders if they missed something.
+
+Unless `--peek` was passed, returned messages are auto-marked as read by the tool. Don't warn, just show them.

--- a/commands/notify.md
+++ b/commands/notify.md
@@ -1,0 +1,22 @@
+---
+description: Send a direct notification to one specific session on this project. Wraps broadcast with a target session and warning priority.
+argument-hint: <session-id> <message>
+---
+
+Call the `claude-presence` MCP `broadcast` tool with `to_session` set and `priority: 'warning'` so the recipient sees it on their next prompt without calling `/inbox`.
+
+Parse `$ARGUMENTS`:
+- The first whitespace-delimited token is the recipient `session-id`.
+- The rest is the `message`. If either is missing, ask the user.
+
+If you don't know the candidate session ids, suggest the user run `/presence` first.
+
+Required args for the tool:
+- `session_id`: this session's id (from `session_register`). If unknown, ask the user to `/register` first.
+- `project`: the project's absolute path.
+- `from_branch`: the current git branch if available; omit otherwise.
+- `to_session`: the parsed recipient id.
+- `priority`: `"warning"` (so the message is auto-surfaced on the recipient's next prompt).
+- `message`: the parsed message string.
+
+After posting, confirm in one line: `notified <recipient> (warning, id <n>)`.

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 # claude-presence — UserPromptSubmit hook
 #
-# Injects a one-line status of other sessions on the same project into the prompt context.
-# Runs on every user prompt, so it MUST be fast (< 100ms).
+# Surfaces unread inbox messages and a one-line presence summary on each prompt.
+# Direct messages (to_session = me) and warning/urgent broadcasts are injected
+# verbatim. Lower-priority broadcasts only contribute to the counter.
 #
-# Install: add to ~/.claude/settings.json
-#   {
-#     "hooks": {
-#       "UserPromptSubmit": [
-#         { "matcher": "*", "hooks": [{ "type": "command", "command": "/path/to/user-prompt-submit.sh" }] }
-#       ]
-#     }
-#   }
+# Runs on every user prompt, so it MUST be fast (< 100ms).
 
 set -euo pipefail
 
@@ -23,7 +17,6 @@ if [ -z "${CWD:-}" ]; then
   CWD="$(pwd)"
 fi
 
-# Silently succeed if CLI isn't installed — don't block the prompt.
 if ! command -v claude-presence >/dev/null 2>&1; then
   exit 0
 fi
@@ -32,29 +25,83 @@ STATUS_JSON="$(claude-presence status --project "$CWD" --json 2>/dev/null || ech
 LOCKS_JSON="$(claude-presence locks --project "$CWD" --json 2>/dev/null || echo '[]')"
 
 OTHER_COUNT="$(printf '%s' "$STATUS_JSON" | grep -c '"id"' || true)"
-# Subtract ourselves if session_id is known
 if [ -n "${SESSION_ID:-}" ] && printf '%s' "$STATUS_JSON" | grep -q "\"$SESSION_ID\""; then
   OTHER_COUNT=$((OTHER_COUNT - 1))
 fi
-
 LOCK_COUNT="$(printf '%s' "$LOCKS_JSON" | grep -c '"resource"' || true)"
 
-if [ "$OTHER_COUNT" -le 0 ] && [ "$LOCK_COUNT" -le 0 ]; then
+# Peek high-priority messages addressed to this session (DMs + warning/urgent broadcasts).
+# Peek = no mark-as-read, so /inbox still shows them.
+INBOX_TEXT=""
+INBOX_COUNT=0
+if [ -n "${SESSION_ID:-}" ]; then
+  INBOX_JSON="$(claude-presence inbox --project "$CWD" --session "$SESSION_ID" --peek --json 2>/dev/null || echo '{}')"
+  INBOX_COUNT="$(printf '%s' "$INBOX_JSON" | sed -n 's/.*"unread_total"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -n 1)"
+  INBOX_COUNT="${INBOX_COUNT:-0}"
+
+  # Surface DMs and warning/urgent broadcasts as full text (not just a counter).
+  HIGH_JSON="$(claude-presence inbox --project "$CWD" --session "$SESSION_ID" --peek --min-priority warning --json 2>/dev/null || echo '{}')"
+  if printf '%s' "$HIGH_JSON" | grep -q '"messages"'; then
+    INBOX_TEXT="$(node -e '
+      let s = "";
+      process.stdin.on("data", (d) => (s += d));
+      process.stdin.on("end", () => {
+        try {
+          const r = JSON.parse(s);
+          const msgs = (r && r.messages) || [];
+          if (!msgs.length) return;
+          const lines = msgs.map((m) => {
+            const target = m.to_session ? "DM" : "broadcast";
+            const tag = m.priority && m.priority !== "info" ? "[" + m.priority + "] " : "";
+            return "- " + tag + target + " from " + m.from_session + (m.from_branch ? " (" + m.from_branch + ")" : "") + ": " + m.message.replace(/\s+/g, " ");
+          });
+          process.stdout.write(lines.join("\n"));
+        } catch (e) {}
+      });
+    ' <<EOF
+$HIGH_JSON
+EOF
+    )"
+  fi
+fi
+
+if [ "$OTHER_COUNT" -le 0 ] && [ "$LOCK_COUNT" -le 0 ] && [ "${INBOX_COUNT:-0}" -le 0 ]; then
   exit 0
 fi
 
-MSG="claude-presence: "
+SUMMARY="claude-presence: "
+SEP=""
 if [ "$OTHER_COUNT" -gt 0 ]; then
-  MSG="${MSG}${OTHER_COUNT} other session(s) active on this project"
+  SUMMARY="${SUMMARY}${OTHER_COUNT} other session(s) active"
+  SEP=", "
 fi
 if [ "$LOCK_COUNT" -gt 0 ]; then
-  [ "$OTHER_COUNT" -gt 0 ] && MSG="${MSG}, "
-  MSG="${MSG}${LOCK_COUNT} active resource lock(s)"
+  SUMMARY="${SUMMARY}${SEP}${LOCK_COUNT} active lock(s)"
+  SEP=", "
 fi
-MSG="${MSG}. Call session_list and resource_list for details before shared operations."
+if [ "${INBOX_COUNT:-0}" -gt 0 ]; then
+  SUMMARY="${SUMMARY}${SEP}${INBOX_COUNT} unread inbox message(s)"
+fi
+SUMMARY="${SUMMARY}."
+
+if [ -n "$INBOX_TEXT" ]; then
+  CONTEXT="${SUMMARY}
+
+Pending notifications (peek, still unread — call read_inbox to mark as read):
+${INBOX_TEXT}"
+else
+  CONTEXT="${SUMMARY} Call session_list, resource_list, or read_inbox for details before shared operations."
+fi
+
+# JSON-escape the context payload.
+ESCAPED="$(printf '%s' "$CONTEXT" | node -e '
+  let s = "";
+  process.stdin.on("data", (d) => (s += d));
+  process.stdin.on("end", () => process.stdout.write(JSON.stringify(s)));
+')"
 
 cat <<EOF
 {
-  "additionalContext": "$MSG"
+  "additionalContext": ${ESCAPED}
 }
 EOF

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,32 +2,52 @@
 import { openDatabase, getDefaultDbPath } from "../db/index.js";
 import { Repository } from "../db/repository.js";
 
-const COMMANDS = ["status", "locks", "clear", "path", "help"] as const;
+const COMMANDS = ["status", "locks", "inbox", "clear", "path", "help"] as const;
 type Command = (typeof COMMANDS)[number];
 
-function parseArgs(argv: string[]): {
+interface CliArgs {
   command: Command;
   project?: string;
+  session?: string;
+  minPriority?: "info" | "warning" | "urgent";
   json: boolean;
   all: boolean;
-} {
+  unreadOnly: boolean;
+  peek: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
   const args = argv.slice(2);
   const command = ((args[0] ?? "status") as Command);
   let project: string | undefined;
+  let session: string | undefined;
+  let minPriority: CliArgs["minPriority"];
   let json = false;
   let all = false;
+  let unreadOnly = true;
+  let peek = false;
 
   for (let i = 1; i < args.length; i++) {
     const a = args[i];
     if (a === "--project" || a === "-p") {
       project = args[++i];
+    } else if (a === "--session" || a === "-s") {
+      session = args[++i];
+    } else if (a === "--min-priority") {
+      const v = args[++i];
+      if (v === "info" || v === "warning" || v === "urgent") minPriority = v;
     } else if (a === "--json") {
       json = true;
     } else if (a === "--all") {
       all = true;
+      // For inbox: --all means include already-read messages.
+      // For clear: --all also enables inbox pruning. Same flag, different command.
+      unreadOnly = false;
+    } else if (a === "--peek") {
+      peek = true;
     }
   }
-  return { command, project, json, all };
+  return { command, project, session, minPriority, json, all, unreadOnly, peek };
 }
 
 function formatRelative(ms: number): string {
@@ -85,8 +105,53 @@ function printLocks(repo: Repository, project: string | undefined, json: boolean
   }
 }
 
+function printInbox(repo: Repository, args: CliArgs) {
+  if (!args.session) {
+    if (args.json) {
+      console.log(JSON.stringify({ error: "missing --session <id>" }));
+    } else {
+      console.error("inbox requires --session <id>");
+    }
+    process.exit(1);
+  }
+  if (!args.project) {
+    if (args.json) {
+      console.log(JSON.stringify({ error: "missing --project <path>" }));
+    } else {
+      console.error("inbox requires --project <path>");
+    }
+    process.exit(1);
+  }
+  const result = repo.readInbox({
+    project: args.project,
+    session_id: args.session,
+    unread_only: args.unreadOnly,
+    peek: args.peek,
+    min_priority: args.minPriority,
+  });
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  if (result.messages.length === 0) {
+    console.log(args.unreadOnly ? "No new messages." : "No messages.");
+    return;
+  }
+  console.log(
+    `${result.messages.length} message(s)  [unread: ${result.unread_total}, total: ${result.total}]\n`,
+  );
+  for (const m of result.messages) {
+    const target = m.to_session ? `→ ${m.to_session}` : "→ all";
+    const tag = m.priority === "info" ? "" : `[${m.priority}] `;
+    console.log(
+      `  ${tag}${formatRelative(m.created_at)} from ${m.from_session}${m.from_branch ? ` (${m.from_branch})` : ""} ${target}`,
+    );
+    console.log(`    ${m.message}\n`);
+  }
+}
+
 function printHelp() {
-  console.log(`claude-presence — inter-session coordination for Claude Code
+  console.log(`claude-presence — inter-session coordination
 
 Usage:
   claude-presence <command> [options]
@@ -94,25 +159,30 @@ Usage:
 Commands:
   status              Show active sessions (default)
   locks               Show active resource locks
+  inbox               Read messages for a session (requires --session, --project)
   clear               Prune dead sessions and expired locks
   path                Print the SQLite database path
   help                Show this help
 
 Options:
   --project <path>    Filter to a specific project
-  --json              Output JSON instead of human-readable text
-  --all               (clear) include inbox cleanup
+  --session <id>      Session id (inbox)
+  --min-priority <p>  Filter inbox by min priority (info|warning|urgent)
+  --peek              (inbox) Read without marking as read
+  --json              Output JSON
+  --all               (clear) include inbox cleanup; (inbox) include already-read
 
 Examples:
   claude-presence status
-  claude-presence status --project /Volumes/DataIA/Projets/myapp
   claude-presence locks --json
+  claude-presence inbox --project /path/to/repo --session sess-A --peek --json
   claude-presence clear --all
 `);
 }
 
 async function main() {
-  const { command, project, json, all } = parseArgs(process.argv);
+  const args = parseArgs(process.argv);
+  const { command, project, json, all } = args;
 
   if (command === "help" || !COMMANDS.includes(command)) {
     printHelp();
@@ -132,6 +202,8 @@ async function main() {
       printStatus(repo, project, json);
     } else if (command === "locks") {
       printLocks(repo, project, json);
+    } else if (command === "inbox") {
+      printInbox(repo, args);
     } else if (command === "clear") {
       const sessions = repo.pruneDeadSessions();
       const locks = repo.pruneExpiredLocks();

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -26,11 +26,15 @@ export interface ResourceLockRow {
   expires_at: number;
 }
 
+export type InboxPriority = "info" | "warning" | "urgent";
+
 export interface InboxRow {
   id: number;
   project: string;
   from_session: string;
   from_branch: string | null;
+  to_session: string | null;
+  priority: InboxPriority;
   message: string;
   tags: string | null;
   created_at: number;
@@ -52,5 +56,20 @@ export function openDatabase(dbPath: string = getDefaultDbPath()): Database.Data
   db.pragma("foreign_keys = ON");
   db.pragma("busy_timeout = 5000");
   db.exec(SCHEMA_SQL);
+  migrateInbox(db);
   return db;
+}
+
+function migrateInbox(db: Database.Database): void {
+  const cols = db
+    .prepare("PRAGMA table_info(inbox)")
+    .all() as Array<{ name: string }>;
+  const has = (name: string) => cols.some((c) => c.name === name);
+  if (!has("to_session")) {
+    db.exec("ALTER TABLE inbox ADD COLUMN to_session TEXT");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_to_session ON inbox(to_session)");
+  }
+  if (!has("priority")) {
+    db.exec("ALTER TABLE inbox ADD COLUMN priority TEXT NOT NULL DEFAULT 'info'");
+  }
 }

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -4,7 +4,12 @@ import {
   LOCK_DEFAULT_TTL_MS,
   SESSION_TTL_MS,
 } from "./schema.js";
-import type { InboxRow, ResourceLockRow, SessionRow } from "./index.js";
+import type {
+  InboxPriority,
+  InboxRow,
+  ResourceLockRow,
+  SessionRow,
+} from "./index.js";
 
 export interface RegisterSessionInput {
   id: string;
@@ -255,18 +260,22 @@ export class Repository {
     project: string;
     from_session: string;
     from_branch?: string | null;
+    to_session?: string | null;
+    priority?: InboxPriority | null;
     message: string;
     tags?: string[] | null;
   }): InboxRow {
     this.pruneOldInbox();
     const stmt = this.db.prepare(`
-      INSERT INTO inbox (project, from_session, from_branch, message, tags, created_at)
-      VALUES (@project, @from_session, @from_branch, @message, @tags, @created_at)
+      INSERT INTO inbox (project, from_session, from_branch, to_session, priority, message, tags, created_at)
+      VALUES (@project, @from_session, @from_branch, @to_session, @priority, @message, @tags, @created_at)
     `);
     const result = stmt.run({
       project: input.project,
       from_session: input.from_session,
       from_branch: input.from_branch ?? null,
+      to_session: input.to_session ?? null,
+      priority: input.priority ?? "info",
       message: input.message,
       tags: input.tags ? JSON.stringify(input.tags) : null,
       created_at: this.now(),
@@ -281,9 +290,24 @@ export class Repository {
     session_id: string;
     unread_only?: boolean;
     limit?: number;
+    peek?: boolean;
+    min_priority?: InboxPriority;
   }): { messages: InboxRow[]; unread_total: number; total: number } {
     this.pruneOldInbox();
     const limit = input.limit ?? 50;
+
+    // Visibility: messages addressed to me (to_session = me) OR broadcast (to_session IS NULL).
+    // Always exclude my own posts.
+    const visibility =
+      "i.project = ? AND i.from_session != ? AND (i.to_session IS NULL OR i.to_session = ?)";
+    const visibilityArgs = [
+      input.project,
+      input.session_id,
+      input.session_id,
+    ] as const;
+
+    const priorityFilter = priorityFilterClause(input.min_priority);
+
     let rows: InboxRow[];
 
     if (input.unread_only) {
@@ -293,50 +317,43 @@ export class Repository {
           SELECT i.* FROM inbox i
           LEFT JOIN inbox_reads r
             ON r.message_id = i.id AND r.session_id = ?
-          WHERE i.project = ? AND r.message_id IS NULL AND i.from_session != ?
+          WHERE ${visibility} AND r.message_id IS NULL${priorityFilter}
           ORDER BY i.created_at DESC
           LIMIT ?
         `,
         )
-        .all(
-          input.session_id,
-          input.project,
-          input.session_id,
-          limit,
-        ) as InboxRow[];
+        .all(input.session_id, ...visibilityArgs, limit) as InboxRow[];
     } else {
       rows = this.db
         .prepare(
           `
-          SELECT * FROM inbox
-          WHERE project = ? AND from_session != ?
-          ORDER BY created_at DESC
+          SELECT i.* FROM inbox i
+          WHERE ${visibility}${priorityFilter}
+          ORDER BY i.created_at DESC
           LIMIT ?
         `,
         )
-        .all(input.project, input.session_id, limit) as InboxRow[];
+        .all(...visibilityArgs, limit) as InboxRow[];
     }
 
-    // Counts are computed BEFORE marking as read, so the caller sees
-    // how many unread messages existed at the moment of the call.
     const unreadCountRow = this.db
       .prepare(
         `
         SELECT COUNT(*) AS n FROM inbox i
         LEFT JOIN inbox_reads r
           ON r.message_id = i.id AND r.session_id = ?
-        WHERE i.project = ? AND r.message_id IS NULL AND i.from_session != ?
+        WHERE ${visibility} AND r.message_id IS NULL${priorityFilter}
       `,
       )
-      .get(input.session_id, input.project, input.session_id) as { n: number };
+      .get(input.session_id, ...visibilityArgs) as { n: number };
 
     const totalCountRow = this.db
       .prepare(
-        `SELECT COUNT(*) AS n FROM inbox WHERE project = ? AND from_session != ?`,
+        `SELECT COUNT(*) AS n FROM inbox i WHERE ${visibility}${priorityFilter}`,
       )
-      .get(input.project, input.session_id) as { n: number };
+      .get(...visibilityArgs) as { n: number };
 
-    if (rows.length > 0) {
+    if (rows.length > 0 && !input.peek) {
       const markStmt = this.db.prepare(
         "INSERT OR IGNORE INTO inbox_reads (session_id, message_id, read_at) VALUES (?, ?, ?)",
       );
@@ -353,4 +370,10 @@ export class Repository {
       total: totalCountRow.n,
     };
   }
+}
+
+function priorityFilterClause(min?: InboxPriority): string {
+  if (!min || min === "info") return "";
+  if (min === "warning") return " AND i.priority IN ('warning', 'urgent')";
+  return " AND i.priority = 'urgent'";
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,12 +34,15 @@ CREATE TABLE IF NOT EXISTS inbox (
   project TEXT NOT NULL,
   from_session TEXT NOT NULL,
   from_branch TEXT,
+  to_session TEXT,
+  priority TEXT NOT NULL DEFAULT 'info' CHECK (priority IN ('info', 'warning', 'urgent')),
   message TEXT NOT NULL,
   tags TEXT,
   created_at INTEGER NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_inbox_project ON inbox(project, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_inbox_to_session ON inbox(to_session);
 
 CREATE TABLE IF NOT EXISTS inbox_reads (
   session_id TEXT NOT NULL,

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -50,6 +50,8 @@ export function formatInbox(row: InboxRow) {
     project: row.project,
     from_session: row.from_session,
     from_branch: row.from_branch,
+    to_session: row.to_session,
+    priority: row.priority,
     message: row.message,
     tags: row.tags ? safeParse(row.tags) : null,
     created_at: isoOrNull(row.created_at),

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -2,22 +2,38 @@ import { z } from "zod";
 import type { Repository } from "../db/repository.js";
 import { formatInbox, type McpTool } from "./helpers.js";
 
+const PRIORITY_VALUES = ["info", "warning", "urgent"] as const;
+
 export function inboxTools(repo: Repository): McpTool[] {
   return [
     {
       name: "broadcast",
       description:
-        "Post a short message to the project-wide inbox so other sessions on the same project can see it. Use for heads-ups like 'refactored auth module, watch for merge conflicts' or 'about to run long migration on staging'. Keep it short.",
+        "Post a message to the project inbox. By default broadcasts to every session on the project; set to_session to address one session privately. priority controls automatic surfacing on other sessions: 'warning' and 'urgent' are injected on each prompt without requiring read_inbox.",
       inputShape: {
         session_id: z.string().min(1),
         project: z.string().min(1),
         from_branch: z.string().optional(),
+        to_session: z
+          .string()
+          .min(1)
+          .optional()
+          .describe(
+            "Target one session by id. Omit for a project-wide broadcast.",
+          ),
+        priority: z
+          .enum(PRIORITY_VALUES)
+          .optional()
+          .default("info")
+          .describe(
+            "info (default): silent until /inbox. warning/urgent: surfaced automatically on other sessions' next prompt.",
+          ),
         message: z.string().min(1).max(2000),
         tags: z
           .array(z.string())
           .optional()
           .describe(
-            "Optional tags for filtering (e.g. ['warning', 'ci', 'refactor']).",
+            "Optional tags for filtering (e.g. ['ci', 'refactor']).",
           ),
       },
       handler: async (args) => {
@@ -25,6 +41,8 @@ export function inboxTools(repo: Repository): McpTool[] {
           project: args.project,
           from_session: args.session_id,
           from_branch: args.from_branch ?? null,
+          to_session: args.to_session ?? null,
+          priority: args.priority ?? "info",
           message: args.message,
           tags: args.tags ?? null,
         });
@@ -34,7 +52,7 @@ export function inboxTools(repo: Repository): McpTool[] {
     {
       name: "read_inbox",
       description:
-        "Read recent broadcasts from other sessions on this project. Messages from your own session are excluded. By default returns unread messages only.",
+        "Read messages addressed to this session — direct messages (to_session = me) plus project-wide broadcasts. Own posts are excluded. By default returns unread only and marks them read; pass peek: true to look without marking.",
       inputShape: {
         session_id: z.string().min(1),
         project: z.string().min(1),
@@ -43,6 +61,19 @@ export function inboxTools(repo: Repository): McpTool[] {
           .optional()
           .default(true)
           .describe("Default true: only return messages you haven't seen yet."),
+        peek: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe(
+            "Default false. When true, do not mark returned messages as read.",
+          ),
+        min_priority: z
+          .enum(PRIORITY_VALUES)
+          .optional()
+          .describe(
+            "Filter to messages at or above this priority. Omit for all.",
+          ),
         limit: z.number().int().positive().max(200).optional().default(50),
       },
       handler: async (args) => {
@@ -50,6 +81,8 @@ export function inboxTools(repo: Repository): McpTool[] {
           project: args.project,
           session_id: args.session_id,
           unread_only: args.unread_only,
+          peek: args.peek,
+          min_priority: args.min_priority,
           limit: args.limit,
         });
         return {

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import { Repository } from "../src/db/repository.js";
+import { freshRepo } from "./helpers.js";
+
+describe("inbox — direct messages, peek, priority", () => {
+  let repo: Repository;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    ({ repo, db } = freshRepo());
+    repo.registerSession({ id: "alice", project: "/repo" });
+    repo.registerSession({ id: "bob", project: "/repo" });
+    repo.registerSession({ id: "carol", project: "/repo" });
+  });
+
+  afterEach(() => db.close());
+
+  it("delivers a DM only to the targeted session", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      to_session: "bob",
+      message: "hi bob",
+    });
+
+    const bobInbox = repo.readInbox({ project: "/repo", session_id: "bob" });
+    expect(bobInbox.messages).toHaveLength(1);
+    expect(bobInbox.messages[0].to_session).toBe("bob");
+    expect(bobInbox.messages[0].message).toBe("hi bob");
+
+    const carolInbox = repo.readInbox({ project: "/repo", session_id: "carol" });
+    expect(carolInbox.messages).toHaveLength(0);
+    expect(carolInbox.total).toBe(0);
+  });
+
+  it("delivers broadcasts to every other session", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "everyone read this",
+    });
+
+    const bob = repo.readInbox({ project: "/repo", session_id: "bob" });
+    const carol = repo.readInbox({ project: "/repo", session_id: "carol" });
+    expect(bob.messages).toHaveLength(1);
+    expect(carol.messages).toHaveLength(1);
+    expect(bob.messages[0].to_session).toBeNull();
+  });
+
+  it("peek does not mark messages as read", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "ping",
+    });
+
+    const peek = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: true,
+      peek: true,
+    });
+    expect(peek.messages).toHaveLength(1);
+    expect(peek.unread_total).toBe(1);
+
+    const second = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: true,
+    });
+    expect(second.messages).toHaveLength(1);
+    expect(second.unread_total).toBe(1);
+
+    const third = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: true,
+    });
+    expect(third.messages).toHaveLength(0);
+    expect(third.unread_total).toBe(0);
+  });
+
+  it("stores priority and defaults to info", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "default",
+    });
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "warn",
+      priority: "warning",
+    });
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "urgent",
+      priority: "urgent",
+    });
+
+    const all = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: false,
+    });
+    const byMessage = Object.fromEntries(
+      all.messages.map((m) => [m.message, m.priority]),
+    );
+    expect(byMessage.default).toBe("info");
+    expect(byMessage.warn).toBe("warning");
+    expect(byMessage.urgent).toBe("urgent");
+  });
+
+  it("min_priority filters out lower-priority messages", () => {
+    repo.broadcast({ project: "/repo", from_session: "alice", message: "info-msg" });
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "warn-msg",
+      priority: "warning",
+    });
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "urgent-msg",
+      priority: "urgent",
+    });
+
+    const warningsAndUp = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: false,
+      min_priority: "warning",
+    });
+    expect(warningsAndUp.messages.map((m) => m.message).sort()).toEqual([
+      "urgent-msg",
+      "warn-msg",
+    ]);
+    expect(warningsAndUp.total).toBe(2);
+
+    const urgentOnly = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: false,
+      min_priority: "urgent",
+    });
+    expect(urgentOnly.messages).toHaveLength(1);
+    expect(urgentOnly.messages[0].message).toBe("urgent-msg");
+  });
+
+  it("counts and visibility honor DM targeting (Carol cannot peek Bob's DMs)", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      to_session: "bob",
+      message: "private",
+    });
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      message: "public",
+    });
+
+    const carol = repo.readInbox({
+      project: "/repo",
+      session_id: "carol",
+      unread_only: false,
+    });
+    expect(carol.messages).toHaveLength(1);
+    expect(carol.messages[0].message).toBe("public");
+    expect(carol.total).toBe(1);
+  });
+
+  it("DM author is still excluded from their own inbox", () => {
+    repo.broadcast({
+      project: "/repo",
+      from_session: "alice",
+      to_session: "bob",
+      message: "hi",
+    });
+    const aliceInbox = repo.readInbox({
+      project: "/repo",
+      session_id: "alice",
+      unread_only: false,
+    });
+    expect(aliceInbox.messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Direct messages** — `broadcast` accepts `to_session` to address one specific session; `NULL` keeps the project-wide broadcast behavior.
- **Priority** — new `info | warning | urgent` field. `info` (default) stays opt-in via `/inbox`; `warning` and `urgent` are auto-surfaced on every recipient prompt by the `UserPromptSubmit` hook (peek = no mark-as-read), so notifications no longer rely on the recipient remembering to type `/inbox`.
- **`peek` mode** on `read_inbox` reads without consuming unread state — used by the hook so users still see the messages on their next manual `/inbox`.
- **`/notify <session> <message>`** slash command (DM with `priority: warning`), plus `--to` / `--priority` on `/broadcast` and `--peek` / `--min-priority` on `/inbox`.
- **`claude-presence inbox`** new CLI subcommand (`--session`, `--project`, `--peek`, `--min-priority`, `--json`).
- Schema migrated in-place via `ALTER TABLE` (new columns `inbox.to_session`, `inbox.priority` defaulted to `info`); existing local DBs upgrade transparently on first open.

## Test plan

- [x] `npm test` — 76/76 green locally (was 69, +7 dedicated tests in `tests/notifications.test.ts`)
- [x] Manual hook smoke test: posting a `warning` DM to session A surfaces it as `additionalContext` on A's next prompt without marking it read; subsequent `/inbox` still shows it
- [x] `grep` for forbidden mentions — clean
- [ ] CI green on Ubuntu + macOS × Node 18/20/22 (6 jobs)