### PR TITLE
feat: auto-refresh session branch on git checkout

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -81,6 +81,7 @@ C'est toute la boucle. Tout le reste ci-dessous, c'est du détail.
 - **CLI** — `claude-presence status` montre les sessions actives hors Claude Code
 - **Zéro démon (mode stdio)** — adossé à SQLite, sans port, sans processus en arrière-plan pour l'usage solo / mono-machine
 - **Mode équipe (v0.2+)** — serveur HTTP auto-hébergé optionnel avec auth bearer-token et RBAC pour coordonner plusieurs machines
+- **Rafraîchissement auto de la branche** — quand l'utilisateur fait `git checkout`, la branche stockée est mise à jour silencieusement au prompt suivant
 - **Nettoyage par TTL** — les sessions sans heartbeat depuis 24 heures sont purgées automatiquement
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ That's the whole loop. Everything below is detail.
 - **CLI** — `claude-presence status` shows active sessions outside Claude Code
 - **Zero daemon (stdio mode)** — SQLite-backed, no port, no background process for solo / single-machine use
 - **Team mode (v0.2+)** — optional self-hosted HTTP server with bearer-token auth and RBAC for coordination across machines
+- **Auto branch refresh** — when the user runs `git checkout`, the session's stored branch is updated transparently on the next prompt
 - **TTL-based cleanup** — sessions with no heartbeat for 24 hours are removed automatically
 
 ## Install

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -21,6 +21,21 @@ if ! command -v claude-presence >/dev/null 2>&1; then
   exit 0
 fi
 
+# Auto-refresh the session's branch if it has drifted since the last
+# register/refresh (typical case: the user ran `git checkout` between
+# two prompts). Idempotent and silent — no-op if branch is unchanged
+# or session unknown.
+if [ -n "${SESSION_ID:-}" ] && command -v git >/dev/null 2>&1; then
+  CURRENT_BRANCH="$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ -n "${CURRENT_BRANCH:-}" ]; then
+    claude-presence refresh-branch \
+      --project "$CWD" \
+      --session "$SESSION_ID" \
+      --branch "$CURRENT_BRANCH" \
+      --json >/dev/null 2>&1 || true
+  fi
+fi
+
 STATUS_JSON="$(claude-presence status --project "$CWD" --json 2>/dev/null || echo '[]')"
 LOCKS_JSON="$(claude-presence locks --project "$CWD" --json 2>/dev/null || echo '[]')"
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,13 +2,22 @@
 import { openDatabase, getDefaultDbPath } from "../db/index.js";
 import { Repository } from "../db/repository.js";
 
-const COMMANDS = ["status", "locks", "inbox", "clear", "path", "help"] as const;
+const COMMANDS = [
+  "status",
+  "locks",
+  "inbox",
+  "refresh-branch",
+  "clear",
+  "path",
+  "help",
+] as const;
 type Command = (typeof COMMANDS)[number];
 
 interface CliArgs {
   command: Command;
   project?: string;
   session?: string;
+  branch?: string;
   minPriority?: "info" | "warning" | "urgent";
   json: boolean;
   all: boolean;
@@ -21,6 +30,7 @@ function parseArgs(argv: string[]): CliArgs {
   const command = ((args[0] ?? "status") as Command);
   let project: string | undefined;
   let session: string | undefined;
+  let branch: string | undefined;
   let minPriority: CliArgs["minPriority"];
   let json = false;
   let all = false;
@@ -33,6 +43,8 @@ function parseArgs(argv: string[]): CliArgs {
       project = args[++i];
     } else if (a === "--session" || a === "-s") {
       session = args[++i];
+    } else if (a === "--branch" || a === "-b") {
+      branch = args[++i];
     } else if (a === "--min-priority") {
       const v = args[++i];
       if (v === "info" || v === "warning" || v === "urgent") minPriority = v;
@@ -47,7 +59,17 @@ function parseArgs(argv: string[]): CliArgs {
       peek = true;
     }
   }
-  return { command, project, session, minPriority, json, all, unreadOnly, peek };
+  return {
+    command,
+    project,
+    session,
+    branch,
+    minPriority,
+    json,
+    all,
+    unreadOnly,
+    peek,
+  };
 }
 
 function formatRelative(ms: number): string {
@@ -150,6 +172,59 @@ function printInbox(repo: Repository, args: CliArgs) {
   }
 }
 
+function printRefreshBranch(repo: Repository, args: CliArgs) {
+  if (!args.session || !args.project || !args.branch) {
+    const err = "refresh-branch requires --session, --project, --branch";
+    if (args.json) {
+      console.log(JSON.stringify({ error: err }));
+    } else {
+      console.error(err);
+    }
+    process.exit(1);
+  }
+
+  const existing = repo.getSession(args.session);
+  if (!existing) {
+    const result = { changed: false, reason: "session_not_found" as const };
+    if (args.json) console.log(JSON.stringify(result));
+    else console.log("Session not found; nothing to refresh.");
+    return;
+  }
+  if (existing.project !== args.project) {
+    const result = {
+      changed: false,
+      reason: "project_mismatch" as const,
+      stored_project: existing.project,
+    };
+    if (args.json) console.log(JSON.stringify(result));
+    else console.error(`Project mismatch (stored: ${existing.project}); skipping.`);
+    return;
+  }
+  if (existing.branch === args.branch) {
+    const result = { changed: false, branch: args.branch };
+    if (args.json) console.log(JSON.stringify(result));
+    else console.log(`Branch unchanged (${args.branch}).`);
+    return;
+  }
+
+  repo.registerSession({
+    id: args.session,
+    project: existing.project,
+    branch: args.branch,
+    intent: existing.intent,
+    pid: existing.pid,
+    hostname: existing.hostname,
+  });
+
+  const result = {
+    changed: true,
+    from: existing.branch,
+    to: args.branch,
+  };
+  if (args.json) console.log(JSON.stringify(result));
+  else console.log(`Branch refreshed: ${existing.branch ?? "(none)"} → ${args.branch}.`);
+}
+
 function printHelp() {
   console.log(`claude-presence — inter-session coordination
 
@@ -160,13 +235,15 @@ Commands:
   status              Show active sessions (default)
   locks               Show active resource locks
   inbox               Read messages for a session (requires --session, --project)
+  refresh-branch      Update a session's branch if it has drifted (requires --session, --project, --branch)
   clear               Prune dead sessions and expired locks
   path                Print the SQLite database path
   help                Show this help
 
 Options:
   --project <path>    Filter to a specific project
-  --session <id>      Session id (inbox)
+  --session <id>      Session id (inbox, refresh-branch)
+  --branch <name>     Current git branch (refresh-branch)
   --min-priority <p>  Filter inbox by min priority (info|warning|urgent)
   --peek              (inbox) Read without marking as read
   --json              Output JSON
@@ -176,6 +253,7 @@ Examples:
   claude-presence status
   claude-presence locks --json
   claude-presence inbox --project /path/to/repo --session sess-A --peek --json
+  claude-presence refresh-branch --project /path/to/repo --session sess-A --branch feat/foo
   claude-presence clear --all
 `);
 }
@@ -204,6 +282,8 @@ async function main() {
       printLocks(repo, project, json);
     } else if (command === "inbox") {
       printInbox(repo, args);
+    } else if (command === "refresh-branch") {
+      printRefreshBranch(repo, args);
     } else if (command === "clear") {
       const sessions = repo.pruneDeadSessions();
       const locks = repo.pruneExpiredLocks();

--- a/tests/refresh-branch.test.ts
+++ b/tests/refresh-branch.test.ts
@@ -1,0 +1,199 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type Database from "better-sqlite3";
+import { openDatabase } from "../src/db/index.js";
+import { Repository } from "../src/db/repository.js";
+import { freshRepo } from "./helpers.js";
+
+const CLI_PATH = resolve(__dirname, "..", "dist", "cli", "index.js");
+
+function runCli(env: Record<string, string>, args: string[]): unknown {
+  const out = execFileSync("node", [CLI_PATH, ...args], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  }).trim();
+  return JSON.parse(out);
+}
+
+describe("refresh-branch — idempotent branch update", () => {
+  let repo: Repository;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    ({ repo, db } = freshRepo());
+  });
+
+  afterEach(() => db.close());
+
+  it("updates the stored branch when it drifts", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "main",
+      intent: "fixing auth",
+    });
+
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "feat/login",
+      intent: "fixing auth",
+    });
+
+    const after = repo.getSession("alice");
+    expect(after?.branch).toBe("feat/login");
+    expect(after?.intent).toBe("fixing auth");
+  });
+
+  it("preserves intent and other metadata across a branch refresh", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "main",
+      intent: "fixing auth",
+      pid: 4242,
+      hostname: "laptop",
+    });
+
+    const before = repo.getSession("alice")!;
+
+    repo.registerSession({
+      id: "alice",
+      project: before.project,
+      branch: "feat/x",
+      intent: before.intent,
+      pid: before.pid,
+      hostname: before.hostname,
+    });
+
+    const after = repo.getSession("alice")!;
+    expect(after.branch).toBe("feat/x");
+    expect(after.intent).toBe("fixing auth");
+    expect(after.pid).toBe(4242);
+    expect(after.hostname).toBe("laptop");
+    expect(after.started_at).toBe(before.started_at);
+  });
+
+  it("is a no-op (no row change) when the new branch matches the stored one", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "main",
+    });
+    const before = repo.getSession("alice")!;
+
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "main",
+    });
+    const after = repo.getSession("alice")!;
+
+    expect(after.branch).toBe("main");
+    expect(after.started_at).toBe(before.started_at);
+  });
+
+  it("does nothing for an unknown session", () => {
+    expect(repo.getSession("ghost")).toBeUndefined();
+  });
+
+  it("can transition from a null branch (registered without one) to a real branch", () => {
+    repo.registerSession({ id: "alice", project: "/repo" });
+    expect(repo.getSession("alice")?.branch).toBeNull();
+
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "feat/y",
+    });
+    expect(repo.getSession("alice")?.branch).toBe("feat/y");
+  });
+});
+
+describe("refresh-branch — CLI JSON contract (consumed by the hook)", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let env: Record<string, string>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "claude-presence-cli-"));
+    dbPath = join(tmpDir, "state.db");
+    env = { CLAUDE_PRESENCE_DB: dbPath };
+    const db = openDatabase(dbPath);
+    const repo = new Repository(db);
+    repo.registerSession({
+      id: "alice",
+      project: "/myproj",
+      branch: "main",
+      intent: "foo",
+    });
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("emits {changed:false} when the branch is unchanged", () => {
+    const out = runCli(env, [
+      "refresh-branch",
+      "--project",
+      "/myproj",
+      "--session",
+      "alice",
+      "--branch",
+      "main",
+      "--json",
+    ]);
+    expect(out).toEqual({ changed: false, branch: "main" });
+  });
+
+  it("emits {changed:true, from, to} when the branch drifted", () => {
+    const out = runCli(env, [
+      "refresh-branch",
+      "--project",
+      "/myproj",
+      "--session",
+      "alice",
+      "--branch",
+      "feat/foo",
+      "--json",
+    ]);
+    expect(out).toEqual({ changed: true, from: "main", to: "feat/foo" });
+  });
+
+  it("emits session_not_found for an unknown session id", () => {
+    const out = runCli(env, [
+      "refresh-branch",
+      "--project",
+      "/myproj",
+      "--session",
+      "ghost",
+      "--branch",
+      "main",
+      "--json",
+    ]);
+    expect(out).toEqual({ changed: false, reason: "session_not_found" });
+  });
+
+  it("emits project_mismatch when the cwd does not match the stored project", () => {
+    const out = runCli(env, [
+      "refresh-branch",
+      "--project",
+      "/elsewhere",
+      "--session",
+      "alice",
+      "--branch",
+      "main",
+      "--json",
+    ]);
+    expect(out).toEqual({
+      changed: false,
+      reason: "project_mismatch",
+      stored_project: "/myproj",
+    });
+  });
+});


### PR DESCRIPTION
Closes #13.

## Summary

- New CLI subcommand **`claude-presence refresh-branch --session <id> --project <path> --branch <name> [--json]`**. Idempotent and defensive: no-op if the branch matches the stored value, returns `session_not_found` for unknown sessions, returns `project_mismatch` when the cwd differs from the stored project (prevents cross-project leaks).
- The existing **`UserPromptSubmit` hook** now calls `refresh-branch` silently on every prompt (when both `git` and a `session_id` are available). Failure is swallowed and never blocks the prompt.
- README + README.fr feature-list bullets added.

The user no longer has to type `/register` after `git checkout` — `/presence` and `session_list` show the current branch on the next prompt automatically.

## Test plan

- [x] `npm test` — 85/85 green locally (was 76, +9 dedicated: 5 repo-level invariants + 4 CLI JSON contract tests for the four documented outcomes consumed by the hook)
- [x] Manual smoke test of CLI in all 5 cases (unchanged, drift, idempotent, session_not_found, project_mismatch)
- [x] Manual end-to-end hook test: registered session on `main`, then ran the hook from a different branch — the DB was silently updated to the new branch, no output to the user
- [ ] CI green on Ubuntu + macOS × Node 18/20/22 (6 jobs)

## Notes

- Approach C from the issue (existing-hook-based) was chosen over A/B (PostToolUse matcher / git post-checkout hook). Latency is "between two prompts", which is acceptable for presence info.
- Defensive `project_mismatch` check prevents a session registered for project A from being overwritten if the user happens to invoke the hook in project B's cwd.