### PR TITLE
fix: migrate inbox columns before creating their index

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -67,9 +67,15 @@ function migrateInbox(db: Database.Database): void {
   const has = (name: string) => cols.some((c) => c.name === name);
   if (!has("to_session")) {
     db.exec("ALTER TABLE inbox ADD COLUMN to_session TEXT");
-    db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_to_session ON inbox(to_session)");
   }
   if (!has("priority")) {
     db.exec("ALTER TABLE inbox ADD COLUMN priority TEXT NOT NULL DEFAULT 'info'");
   }
+  // Always (re)attempt the index — IF NOT EXISTS handles fresh DBs and
+  // re-opens after the columns were added. Kept out of SCHEMA_SQL so the
+  // initial db.exec doesn't reference a column that does not exist yet
+  // on databases predating PR #19.
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_inbox_to_session ON inbox(to_session)",
+  );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -42,7 +42,6 @@ CREATE TABLE IF NOT EXISTS inbox (
 );
 
 CREATE INDEX IF NOT EXISTS idx_inbox_project ON inbox(project, created_at DESC);
-CREATE INDEX IF NOT EXISTS idx_inbox_to_session ON inbox(to_session);
 
 CREATE TABLE IF NOT EXISTS inbox_reads (
   session_id TEXT NOT NULL,

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openDatabase } from "../src/db/index.js";
+import { Repository } from "../src/db/repository.js";
+
+// Schema as it shipped in v0.2.1 (before PR #19 added to_session + priority).
+// Reproducing it verbatim ensures we exercise the same migration path real
+// users face when upgrading their on-disk SQLite file.
+const V021_SCHEMA = `
+CREATE TABLE sessions (
+  id TEXT PRIMARY KEY,
+  project TEXT NOT NULL,
+  branch TEXT,
+  intent TEXT,
+  pid INTEGER,
+  hostname TEXT,
+  started_at INTEGER NOT NULL,
+  last_heartbeat INTEGER NOT NULL,
+  metadata TEXT
+);
+CREATE INDEX idx_sessions_project ON sessions(project);
+CREATE INDEX idx_sessions_heartbeat ON sessions(last_heartbeat);
+
+CREATE TABLE resource_locks (
+  resource TEXT NOT NULL,
+  project TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  branch TEXT,
+  reason TEXT,
+  acquired_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  PRIMARY KEY (project, resource),
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_locks_expires ON resource_locks(expires_at);
+CREATE INDEX idx_locks_session ON resource_locks(session_id);
+
+CREATE TABLE inbox (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  from_session TEXT NOT NULL,
+  from_branch TEXT,
+  message TEXT NOT NULL,
+  tags TEXT,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_inbox_project ON inbox(project, created_at DESC);
+
+CREATE TABLE inbox_reads (
+  session_id TEXT NOT NULL,
+  message_id INTEGER NOT NULL,
+  read_at INTEGER NOT NULL,
+  PRIMARY KEY (session_id, message_id)
+);
+`;
+
+describe("openDatabase migration — upgrades v0.2.1 schema in place", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "claude-presence-mig-"));
+    dbPath = join(tmpDir, "state.db");
+
+    // Seed an "old" database exactly as v0.2.1 would have left it,
+    // with one inbox row pre-existing to make sure we don't lose data.
+    const seed = new Database(dbPath);
+    seed.exec(V021_SCHEMA);
+    seed.prepare(
+      "INSERT INTO sessions (id, project, started_at, last_heartbeat) VALUES (?, ?, ?, ?)",
+    ).run("alice", "/repo", Date.now(), Date.now());
+    seed.prepare(
+      "INSERT INTO inbox (project, from_session, message, created_at) VALUES (?, ?, ?, ?)",
+    ).run("/repo", "alice", "legacy message", Date.now());
+    seed.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("opens a v0.2.1 database without throwing", () => {
+    const db = openDatabase(dbPath);
+    db.close();
+  });
+
+  it("adds to_session and priority columns to the existing inbox table", () => {
+    const db = openDatabase(dbPath);
+    const cols = db
+      .prepare("PRAGMA table_info(inbox)")
+      .all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("to_session");
+    expect(names).toContain("priority");
+    db.close();
+  });
+
+  it("creates idx_inbox_to_session after the column is added", () => {
+    const db = openDatabase(dbPath);
+    const indexes = db
+      .prepare("PRAGMA index_list(inbox)")
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("idx_inbox_to_session");
+    db.close();
+  });
+
+  it("preserves pre-existing rows and defaults priority to 'info'", () => {
+    const db = openDatabase(dbPath);
+    const repo = new Repository(db);
+    const inbox = repo.readInbox({
+      project: "/repo",
+      session_id: "bob",
+      unread_only: false,
+    });
+    expect(inbox.messages).toHaveLength(1);
+    expect(inbox.messages[0].message).toBe("legacy message");
+    expect(inbox.messages[0].priority).toBe("info");
+    expect(inbox.messages[0].to_session).toBeNull();
+    db.close();
+  });
+
+  it("is idempotent — opening the migrated db a second time is a no-op", () => {
+    const db1 = openDatabase(dbPath);
+    db1.close();
+    const db2 = openDatabase(dbPath);
+    const cols = db2
+      .prepare("PRAGMA table_info(inbox)")
+      .all() as Array<{ name: string }>;
+    expect(cols.filter((c) => c.name === "to_session")).toHaveLength(1);
+    expect(cols.filter((c) => c.name === "priority")).toHaveLength(1);
+    db2.close();
+  });
+});


### PR DESCRIPTION
## Summary

Live regression discovered while running the freshly relinked CLI on a v0.2.1 on-disk database. PR #19 added `CREATE INDEX idx_inbox_to_session` inside `SCHEMA_SQL`, but `db.exec(SCHEMA_SQL)` runs **before** `migrateInbox()` adds the `to_session` column via `ALTER TABLE`. On any database created before PR #19, the index creation aborted the whole schema bootstrap with `no such column: to_session`, leaving the DB unusable.

## Fix

- Remove the `CREATE INDEX idx_inbox_to_session` line from `SCHEMA_SQL`.
- Always run `CREATE INDEX IF NOT EXISTS idx_inbox_to_session` **inside** `migrateInbox()` after the column-add step. Idempotent in all three cases:
  - fresh DB (column comes from `CREATE TABLE` in `SCHEMA_SQL`)
  - v0.2.1 DB (column added via `ALTER TABLE` just above)
  - re-open of an already-migrated DB (`IF NOT EXISTS` no-ops)

## Test plan

- [x] New `tests/migration.test.ts` seeds the v0.2.1 schema verbatim (with one legacy inbox row), then calls `openDatabase()` and asserts:
  - opens without throwing
  - both columns added, index created
  - legacy row preserved with `priority='info'` and `to_session=null`
  - re-opening the migrated DB is a no-op
- [x] `npm test` — **90/90** green locally (was 85, +5 dedicated regression tests)
- [x] Manual repro: pre-fix code threw `no such column: to_session` on my real `~/.claude-presence/state.db`. Post-fix code opens it cleanly.
- [ ] CI green on Ubuntu + macOS × Node 18/20/22 (6 jobs)

## Notes

This bug would hit any user upgrading from npm `0.2.1` to a future `0.2.2` build, so this fix should ship **before** the v0.2.2 tag.