### PR TITLE
chore: bump better-sqlite3 to v12 and drop Node 18 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [18, 20, 22]
+        node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.fr.md
+++ b/README.fr.md
@@ -412,7 +412,7 @@ deploy/               # déploiements à base de Dockerfile pour le mode équipe
 docs/
   team-mode.md / .fr.md       # guide de déploiement bilingue
 .github/workflows/
-  ci.yml                      # build + test sur Ubuntu + macOS x Node 18/20/22
+  ci.yml                      # build + test sur Ubuntu + macOS x Node 20/22/24
   docker.yml                  # buildx multi-arch + cosign + Trivy (v0.2+)
 ```
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ deploy/               # Dockerfile-based deployments for team mode
 docs/
   team-mode.md / .fr.md       # bilingual deploy guide
 .github/workflows/
-  ci.yml                      # build + test on Ubuntu + macOS x Node 18/20/22
+  ci.yml                      # build + test on Ubuntu + macOS x Node 20/22/24
   docker.yml                  # buildx multi-arch + cosign + Trivy (v0.2+)
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "better-sqlite3": "^11.3.0",
+        "better-sqlite3": "^12.10.0",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -1045,14 +1045,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
-      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1594,9 +1594,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "zod": "^3.23.8"
   },
   "overrides": {
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "fast-uri": "^3.1.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   },
   "homepage": "https://github.com/garniergeorges/claude-presence#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "better-sqlite3": "^11.3.0",
+    "better-sqlite3": "^12.10.0",
     "zod": "^3.23.8"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

Live regression discovered on the maintainer's machine after upgrading to Node 26. `better-sqlite3@^11.x` fails to compile under Node 26 (V8 API deprecations, 6 C++ errors), so `claude-presence status` and the MCP server fail with `Could not locate the bindings file`.

## Fix

- Bump `better-sqlite3` from `^11.3.0` to `^12.10.0`. Upstream v12.0.0 supports Node 20 through 26 and keeps the same public API surface (`Database`, `prepare`, `exec`, `run`, `all`, `get`, `pragma`, `transaction`), so no source changes are needed.
- Tighten `engines.node` to `>=20.0.0` (Node 18 was EOL since 2025-04-30, and upstream v12 doesn't support it anymore).
- Move the CI matrix from `[18, 20, 22]` to `[20, 22, 24]`. Same width (3 versions), drops the EOL'd 18, adds the current LTS-line 24.
- README ASCII trees (EN + FR) updated to mention the new matrix.

## Test plan

- [x] `npm install` succeeds on Node 26 and the native binding compiles
- [x] `npm test` — 90/90 green locally on Node 26 with the rebuilt binding (rebase brought in PR #21's regression test)
- [x] `npm link --force` deployed locally; `claude-presence status` is responsive again
- [ ] CI green on Ubuntu + macOS × Node 20/22/24 (6 jobs)

## Notes

- This unblocks any user running Node 24 or 26. Users on Node 18 will get a clear `engines` warning from npm.
- Should ship before the next npm publish (v0.2.2) so users upgrading from v0.2.1 don't hit the same wall.