### PR TITLE
feat: map client_session_id for hook-based notification surfacing

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -82,6 +82,7 @@ C'est toute la boucle. Tout le reste ci-dessous, c'est du détail.
 - **Zéro démon (mode stdio)** — adossé à SQLite, sans port, sans processus en arrière-plan pour l'usage solo / mono-machine
 - **Mode équipe (v0.2+)** — serveur HTTP auto-hébergé optionnel avec auth bearer-token et RBAC pour coordonner plusieurs machines
 - **Rafraîchissement auto de la branche** — quand l'utilisateur fait `git checkout`, la branche stockée est mise à jour silencieusement au prompt suivant
+- **Notifications auto-surfacées** — les messages directs (`/notify`) et les broadcasts `warning`/`urgent` apparaissent automatiquement au prochain prompt de la session destinataire, sans avoir besoin de taper `/inbox`
 - **Nettoyage par TTL** — les sessions sans heartbeat depuis 24 heures sont purgées automatiquement
 
 ## Installation
@@ -224,9 +225,15 @@ La session B peut maintenant poursuivre.
 Les commandes slash couvrent 99% de l'usage quotidien. Les hooks sont du polissage optionnel pour le dernier 1% :
 
 - **`hooks/session-start.sh`** s'exécute à l'ouverture d'une nouvelle session Claude Code. Il affiche un rappel court pour que tu penses à `/register` et aux verrous de ressources avant les opérations partagées. Il **n'enregistre pas** la session automatiquement (c'est voulu — la commande slash garde l'enregistrement explicite).
-- **`hooks/user-prompt-submit.sh`** s'exécute à chaque prompt utilisateur. Il injecte un message système d'une ligne dans le contexte quand d'autres sessions ou verrous sont actifs sur ce projet, pour que Claude Code reste au courant sans que tu le demandes.
+- **`hooks/user-prompt-submit.sh`** s'exécute à chaque prompt utilisateur. Il injecte un message système d'une ligne dans le contexte quand d'autres sessions ou verrous sont actifs sur ce projet, et fait remonter les messages directs et les broadcasts `warning`/`urgent` mot pour mot pour que la session destinataire les voie à son prochain prompt sans avoir besoin de taper `/inbox`.
 
 > Le hook `UserPromptSubmit` appelle la CLI `claude-presence`, donc elle doit être dans ton `PATH` (géré par `npm link` ou `npm install -g`). Si la CLI est absente, le hook sort silencieusement avec 0 — pas de blocage.
+
+### Comment marche la résolution d'identité
+
+Le hook reçoit l'id de session interne de Claude Code sur stdin, qui **n'est pas** le même que l'id humain que tu choisis au moment de `/register`. La commande slash `/register` stocke donc les deux : à l'invocation elle passe `${CLAUDE_SESSION_ID}` comme `client_session_id`, créant un mapping entre l'id client et celui que tu as choisi. À chaque prompt, le hook appelle `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` pour identifier "moi" et trouver les DM et broadcasts haute-priorité qui m'étaient adressés.
+
+Si aucun mapping n'existe (sessions héritées d'avant cette feature, ou `client_session_id` volontairement omis), le hook dégrade proprement : il affiche toujours le compteur générique (`N autres sessions actives, M non lus`), mais ne peut pas injecter les notifications verbatim.
 
 ### Activation
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ That's the whole loop. Everything below is detail.
 - **Zero daemon (stdio mode)** — SQLite-backed, no port, no background process for solo / single-machine use
 - **Team mode (v0.2+)** — optional self-hosted HTTP server with bearer-token auth and RBAC for coordination across machines
 - **Auto branch refresh** — when the user runs `git checkout`, the session's stored branch is updated transparently on the next prompt
+- **Auto-surfaced notifications** — direct messages (`/notify`) and `warning`/`urgent` broadcasts appear in the recipient session's next prompt automatically, no manual `/inbox` needed
 - **TTL-based cleanup** — sessions with no heartbeat for 24 hours are removed automatically
 
 ## Install
@@ -224,9 +225,15 @@ Session B can now proceed.
 The slash commands cover 99% of daily use. Hooks are optional polish for the last 1%:
 
 - **`hooks/session-start.sh`** runs when you open a new Claude Code session. It prints a short reminder so you remember to `/register` and think about resource locks before shared ops. It does **not** auto-register the session (by design — the slash command keeps it explicit).
-- **`hooks/user-prompt-submit.sh`** runs on every user prompt. It injects a one-line system message into the context when other sessions or locks are active on this project, so Claude Code stays aware without you asking.
+- **`hooks/user-prompt-submit.sh`** runs on every user prompt. It injects a one-line system message into the context when other sessions or locks are active on this project, and surfaces direct messages and `warning`/`urgent` broadcasts verbatim so the recipient sees them on its next prompt without typing `/inbox`.
 
 > The `UserPromptSubmit` hook shells out to the `claude-presence` CLI, so it must be on your `PATH` (handled by `npm link` or `npm install -g`). If the CLI is missing, the hook silently exits 0 — no breakage.
+
+### How identity resolution works
+
+The hook receives Claude Code's internal session id on stdin, which is **not** the same as the human-friendly id you choose at `/register`. The `/register` slash command therefore stores both: when invoked, it passes `${CLAUDE_SESSION_ID}` as `client_session_id`, building a mapping from the client id to your chosen one. On every prompt, the hook calls `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` to find "me" and look up DMs and high-priority broadcasts addressed to that session id.
+
+If no mapping exists (legacy sessions registered before this feature, or `client_session_id` omitted on purpose), the hook degrades gracefully: it still shows the generic counter (`N other sessions active, M unread`), but cannot inject verbatim notifications.
 
 ### Enable them
 

--- a/commands/register.md
+++ b/commands/register.md
@@ -9,6 +9,9 @@ Call the `claude-presence` MCP `session_register` tool with:
 - `branch`: the current git branch (run `git rev-parse --abbrev-ref HEAD` if unknown).
 - `intent`: a one-line description of what this session is doing. If the user provided arguments to this command ($ARGUMENTS), use that as the intent. Otherwise ask the user what they're working on.
 - `pid`: the Claude Code process PID if known (optional).
+- `client_session_id`: the literal value `${CLAUDE_SESSION_ID}`. This lets the `UserPromptSubmit` hook resolve "me" from the session id Claude Code sends on stdin, so direct messages and warning/urgent broadcasts surface automatically on the next prompt without the user typing `/inbox`.
+
+If the tool response is `ok: false` with `reason: "client_session_id_conflict"`, it means another claude-presence session is still mapped to this Claude Code session id (typical case: previous session was not unregistered cleanly). Tell the user the `held_by` id from the response and suggest either `/release` then retry, or registering without `client_session_id` and accepting that auto-surfacing of notifications won't work for this session.
 
 After registration, if other sessions are active on the same project, summarise them briefly (count, their branches, their intents) so the user is aware.
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 INPUT="$(cat)"
-SESSION_ID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+CLIENT_SESSION_ID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
 CWD="$(printf '%s' "$INPUT" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
 
 if [ -z "${CWD:-}" ]; then
@@ -21,16 +21,27 @@ if ! command -v claude-presence >/dev/null 2>&1; then
   exit 0
 fi
 
+# Resolve "me": stdin gives Claude Code's internal session id, but claude-presence
+# stores the user-chosen one passed at /register time. The mapping was set up
+# when /register included client_session_id=${CLAUDE_SESSION_ID}. If no mapping
+# exists yet (legacy sessions, or /register not called), we degrade to the
+# generic counter without verbatim notification injection.
+PRESENCE_SESSION_ID=""
+if [ -n "${CLIENT_SESSION_ID:-}" ]; then
+  RESOLVE_JSON="$(claude-presence resolve-session --client "$CLIENT_SESSION_ID" --project "$CWD" --json 2>/dev/null || echo '{}')"
+  PRESENCE_SESSION_ID="$(printf '%s' "$RESOLVE_JSON" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+
 # Auto-refresh the session's branch if it has drifted since the last
 # register/refresh (typical case: the user ran `git checkout` between
 # two prompts). Idempotent and silent — no-op if branch is unchanged
 # or session unknown.
-if [ -n "${SESSION_ID:-}" ] && command -v git >/dev/null 2>&1; then
+if [ -n "${PRESENCE_SESSION_ID:-}" ] && command -v git >/dev/null 2>&1; then
   CURRENT_BRANCH="$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   if [ -n "${CURRENT_BRANCH:-}" ]; then
     claude-presence refresh-branch \
       --project "$CWD" \
-      --session "$SESSION_ID" \
+      --session "$PRESENCE_SESSION_ID" \
       --branch "$CURRENT_BRANCH" \
       --json >/dev/null 2>&1 || true
   fi
@@ -40,7 +51,7 @@ STATUS_JSON="$(claude-presence status --project "$CWD" --json 2>/dev/null || ech
 LOCKS_JSON="$(claude-presence locks --project "$CWD" --json 2>/dev/null || echo '[]')"
 
 OTHER_COUNT="$(printf '%s' "$STATUS_JSON" | grep -c '"id"' || true)"
-if [ -n "${SESSION_ID:-}" ] && printf '%s' "$STATUS_JSON" | grep -q "\"$SESSION_ID\""; then
+if [ -n "${PRESENCE_SESSION_ID:-}" ] && printf '%s' "$STATUS_JSON" | grep -q "\"$PRESENCE_SESSION_ID\""; then
   OTHER_COUNT=$((OTHER_COUNT - 1))
 fi
 LOCK_COUNT="$(printf '%s' "$LOCKS_JSON" | grep -c '"resource"' || true)"
@@ -49,13 +60,13 @@ LOCK_COUNT="$(printf '%s' "$LOCKS_JSON" | grep -c '"resource"' || true)"
 # Peek = no mark-as-read, so /inbox still shows them.
 INBOX_TEXT=""
 INBOX_COUNT=0
-if [ -n "${SESSION_ID:-}" ]; then
-  INBOX_JSON="$(claude-presence inbox --project "$CWD" --session "$SESSION_ID" --peek --json 2>/dev/null || echo '{}')"
+if [ -n "${PRESENCE_SESSION_ID:-}" ]; then
+  INBOX_JSON="$(claude-presence inbox --project "$CWD" --session "$PRESENCE_SESSION_ID" --peek --json 2>/dev/null || echo '{}')"
   INBOX_COUNT="$(printf '%s' "$INBOX_JSON" | sed -n 's/.*"unread_total"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -n 1)"
   INBOX_COUNT="${INBOX_COUNT:-0}"
 
   # Surface DMs and warning/urgent broadcasts as full text (not just a counter).
-  HIGH_JSON="$(claude-presence inbox --project "$CWD" --session "$SESSION_ID" --peek --min-priority warning --json 2>/dev/null || echo '{}')"
+  HIGH_JSON="$(claude-presence inbox --project "$CWD" --session "$PRESENCE_SESSION_ID" --peek --min-priority warning --json 2>/dev/null || echo '{}')"
   if printf '%s' "$HIGH_JSON" | grep -q '"messages"'; then
     INBOX_TEXT="$(node -e '
       let s = "";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ const COMMANDS = [
   "locks",
   "inbox",
   "refresh-branch",
+  "resolve-session",
   "clear",
   "path",
   "help",
@@ -18,6 +19,7 @@ interface CliArgs {
   project?: string;
   session?: string;
   branch?: string;
+  client?: string;
   minPriority?: "info" | "warning" | "urgent";
   json: boolean;
   all: boolean;
@@ -31,6 +33,7 @@ function parseArgs(argv: string[]): CliArgs {
   let project: string | undefined;
   let session: string | undefined;
   let branch: string | undefined;
+  let client: string | undefined;
   let minPriority: CliArgs["minPriority"];
   let json = false;
   let all = false;
@@ -45,6 +48,8 @@ function parseArgs(argv: string[]): CliArgs {
       session = args[++i];
     } else if (a === "--branch" || a === "-b") {
       branch = args[++i];
+    } else if (a === "--client" || a === "-c") {
+      client = args[++i];
     } else if (a === "--min-priority") {
       const v = args[++i];
       if (v === "info" || v === "warning" || v === "urgent") minPriority = v;
@@ -64,6 +69,7 @@ function parseArgs(argv: string[]): CliArgs {
     project,
     session,
     branch,
+    client,
     minPriority,
     json,
     all,
@@ -225,6 +231,32 @@ function printRefreshBranch(repo: Repository, args: CliArgs) {
   else console.log(`Branch refreshed: ${existing.branch ?? "(none)"} → ${args.branch}.`);
 }
 
+function printResolveSession(repo: Repository, args: CliArgs) {
+  if (!args.client) {
+    const err = "resolve-session requires --client <id>";
+    if (args.json) {
+      console.log(JSON.stringify({ error: err }));
+    } else {
+      console.error(err);
+    }
+    process.exit(1);
+  }
+  const row = repo.findByClientSessionId(args.client, args.project);
+  const payload = row
+    ? { session_id: row.id, project: row.project, branch: row.branch }
+    : { session_id: null };
+  if (args.json) {
+    console.log(JSON.stringify(payload));
+    return;
+  }
+  if (row) {
+    console.log(row.id);
+  } else {
+    console.error("No session mapped to this client_session_id.");
+    process.exit(2);
+  }
+}
+
 function printHelp() {
   console.log(`claude-presence — inter-session coordination
 
@@ -236,6 +268,7 @@ Commands:
   locks               Show active resource locks
   inbox               Read messages for a session (requires --session, --project)
   refresh-branch      Update a session's branch if it has drifted (requires --session, --project, --branch)
+  resolve-session     Resolve a client_session_id (e.g. \${CLAUDE_SESSION_ID}) to its registered session id (requires --client)
   clear               Prune dead sessions and expired locks
   path                Print the SQLite database path
   help                Show this help
@@ -244,6 +277,7 @@ Options:
   --project <path>    Filter to a specific project
   --session <id>      Session id (inbox, refresh-branch)
   --branch <name>     Current git branch (refresh-branch)
+  --client <id>       Opaque client identifier (resolve-session)
   --min-priority <p>  Filter inbox by min priority (info|warning|urgent)
   --peek              (inbox) Read without marking as read
   --json              Output JSON
@@ -254,6 +288,7 @@ Examples:
   claude-presence locks --json
   claude-presence inbox --project /path/to/repo --session sess-A --peek --json
   claude-presence refresh-branch --project /path/to/repo --session sess-A --branch feat/foo
+  claude-presence resolve-session --client \$CLAUDE_SESSION_ID --project /path/to/repo --json
   claude-presence clear --all
 `);
 }
@@ -284,6 +319,8 @@ async function main() {
       printInbox(repo, args);
     } else if (command === "refresh-branch") {
       printRefreshBranch(repo, args);
+    } else if (command === "resolve-session") {
+      printResolveSession(repo, args);
     } else if (command === "clear") {
       const sessions = repo.pruneDeadSessions();
       const locks = repo.pruneExpiredLocks();

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -14,6 +14,7 @@ export interface SessionRow {
   started_at: number;
   last_heartbeat: number;
   metadata: string | null;
+  client_session_id: string | null;
 }
 
 export interface ResourceLockRow {
@@ -57,7 +58,21 @@ export function openDatabase(dbPath: string = getDefaultDbPath()): Database.Data
   db.pragma("busy_timeout = 5000");
   db.exec(SCHEMA_SQL);
   migrateInbox(db);
+  migrateSessions(db);
   return db;
+}
+
+function migrateSessions(db: Database.Database): void {
+  const cols = db
+    .prepare("PRAGMA table_info(sessions)")
+    .all() as Array<{ name: string }>;
+  const has = (name: string) => cols.some((c) => c.name === name);
+  if (!has("client_session_id")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN client_session_id TEXT");
+  }
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_sessions_client_id ON sessions(client_session_id)",
+  );
 }
 
 function migrateInbox(db: Database.Database): void {

--- a/src/db/repository.ts
+++ b/src/db/repository.ts
@@ -19,6 +19,19 @@ export interface RegisterSessionInput {
   pid?: number | null;
   hostname?: string | null;
   metadata?: Record<string, unknown> | null;
+  client_session_id?: string | null;
+}
+
+export class ClientSessionConflictError extends Error {
+  constructor(
+    public readonly client_session_id: string,
+    public readonly held_by: string,
+  ) {
+    super(
+      `client_session_id "${client_session_id}" is already mapped to session "${held_by}"`,
+    );
+    this.name = "ClientSessionConflictError";
+  }
 }
 
 export interface ClaimResult {
@@ -71,9 +84,22 @@ export class Repository {
 
   registerSession(input: RegisterSessionInput): SessionRow {
     const now = this.now();
+    const clientId = input.client_session_id ?? null;
+
+    if (clientId) {
+      const holder = this.db
+        .prepare(
+          "SELECT id FROM sessions WHERE client_session_id = ? AND id != ?",
+        )
+        .get(clientId, input.id) as { id: string } | undefined;
+      if (holder) {
+        throw new ClientSessionConflictError(clientId, holder.id);
+      }
+    }
+
     const stmt = this.db.prepare(`
-      INSERT INTO sessions (id, project, branch, intent, pid, hostname, started_at, last_heartbeat, metadata)
-      VALUES (@id, @project, @branch, @intent, @pid, @hostname, @started_at, @last_heartbeat, @metadata)
+      INSERT INTO sessions (id, project, branch, intent, pid, hostname, started_at, last_heartbeat, metadata, client_session_id)
+      VALUES (@id, @project, @branch, @intent, @pid, @hostname, @started_at, @last_heartbeat, @metadata, @client_session_id)
       ON CONFLICT(id) DO UPDATE SET
         project = excluded.project,
         branch = excluded.branch,
@@ -81,7 +107,8 @@ export class Repository {
         pid = excluded.pid,
         hostname = excluded.hostname,
         last_heartbeat = excluded.last_heartbeat,
-        metadata = excluded.metadata
+        metadata = excluded.metadata,
+        client_session_id = COALESCE(excluded.client_session_id, sessions.client_session_id)
     `);
     stmt.run({
       id: input.id,
@@ -93,8 +120,26 @@ export class Repository {
       started_at: now,
       last_heartbeat: now,
       metadata: input.metadata ? JSON.stringify(input.metadata) : null,
+      client_session_id: clientId,
     });
     return this.getSession(input.id)!;
+  }
+
+  findByClientSessionId(
+    clientSessionId: string,
+    project?: string,
+  ): SessionRow | undefined {
+    this.pruneDeadSessions();
+    if (project) {
+      return this.db
+        .prepare(
+          "SELECT * FROM sessions WHERE client_session_id = ? AND project = ?",
+        )
+        .get(clientSessionId, project) as SessionRow | undefined;
+    }
+    return this.db
+      .prepare("SELECT * FROM sessions WHERE client_session_id = ?")
+      .get(clientSessionId) as SessionRow | undefined;
   }
 
   heartbeat(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   hostname TEXT,
   started_at INTEGER NOT NULL,
   last_heartbeat INTEGER NOT NULL,
-  metadata TEXT
+  metadata TEXT,
+  client_session_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project);

--- a/src/tools/presence.ts
+++ b/src/tools/presence.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import type { Repository } from "../db/repository.js";
+import {
+  ClientSessionConflictError,
+  type Repository,
+} from "../db/repository.js";
 import { formatSession, type McpTool } from "./helpers.js";
 
 export function presenceTools(repo: Repository): McpTool[] {
@@ -28,16 +31,38 @@ export function presenceTools(repo: Repository): McpTool[] {
           ),
         pid: z.number().int().optional().describe("Your process PID."),
         hostname: z.string().optional().describe("Machine hostname."),
+        client_session_id: z
+          .string()
+          .optional()
+          .describe(
+            "Opaque client identifier (e.g. Claude Code's internal session UUID from ${CLAUDE_SESSION_ID}). Lets hooks resolve 'me' from stdin without knowing the human-friendly session_id.",
+          ),
       },
       handler: async (args) => {
-        const row = repo.registerSession({
-          id: args.session_id,
-          project: args.project,
-          branch: args.branch ?? null,
-          intent: args.intent ?? null,
-          pid: args.pid ?? null,
-          hostname: args.hostname ?? null,
-        });
+        let row;
+        try {
+          row = repo.registerSession({
+            id: args.session_id,
+            project: args.project,
+            branch: args.branch ?? null,
+            intent: args.intent ?? null,
+            pid: args.pid ?? null,
+            hostname: args.hostname ?? null,
+            client_session_id: args.client_session_id ?? null,
+          });
+        } catch (err) {
+          if (err instanceof ClientSessionConflictError) {
+            return {
+              ok: false,
+              reason: "client_session_id_conflict",
+              client_session_id: err.client_session_id,
+              held_by: err.held_by,
+              advice:
+                "Another claude-presence session is already mapped to this client_session_id. Use session_unregister on the stale session, or omit client_session_id to register without auto-resolution.",
+            };
+          }
+          throw err;
+        }
         const others = repo
           .listSessions(args.project)
           .filter((s) => s.id !== args.session_id);

--- a/tests/client-session-mapping.test.ts
+++ b/tests/client-session-mapping.test.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openDatabase } from "../src/db/index.js";
+import {
+  ClientSessionConflictError,
+  Repository,
+} from "../src/db/repository.js";
+import { freshRepo } from "./helpers.js";
+
+const CLI_PATH = resolve(__dirname, "..", "dist", "cli", "index.js");
+
+function runCli(env: Record<string, string>, args: string[]): unknown {
+  const out = execFileSync("node", [CLI_PATH, ...args], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  }).trim();
+  return JSON.parse(out);
+}
+
+describe("client_session_id mapping — Repository", () => {
+  let repo: Repository;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    ({ repo, db } = freshRepo());
+  });
+
+  afterEach(() => db.close());
+
+  it("stores client_session_id when provided at register", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      client_session_id: "uuid-aaa",
+    });
+    const row = repo.getSession("alice");
+    expect(row?.client_session_id).toBe("uuid-aaa");
+  });
+
+  it("findByClientSessionId returns the mapped session", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      client_session_id: "uuid-aaa",
+    });
+    const found = repo.findByClientSessionId("uuid-aaa");
+    expect(found?.id).toBe("alice");
+  });
+
+  it("findByClientSessionId returns undefined when no mapping exists", () => {
+    repo.registerSession({ id: "alice", project: "/repo" });
+    expect(repo.findByClientSessionId("uuid-ghost")).toBeUndefined();
+  });
+
+  it("scopes findByClientSessionId by project when provided", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo-A",
+      client_session_id: "uuid-aaa",
+    });
+    expect(repo.findByClientSessionId("uuid-aaa", "/repo-A")?.id).toBe("alice");
+    expect(repo.findByClientSessionId("uuid-aaa", "/repo-B")).toBeUndefined();
+  });
+
+  it("throws ClientSessionConflictError when a different session reclaims the same client_session_id", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      client_session_id: "uuid-aaa",
+    });
+    expect(() =>
+      repo.registerSession({
+        id: "bob",
+        project: "/repo",
+        client_session_id: "uuid-aaa",
+      }),
+    ).toThrow(ClientSessionConflictError);
+  });
+
+  it("does not throw when the same session re-registers with the same client_session_id", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      client_session_id: "uuid-aaa",
+    });
+    expect(() =>
+      repo.registerSession({
+        id: "alice",
+        project: "/repo",
+        branch: "feat/x",
+        client_session_id: "uuid-aaa",
+      }),
+    ).not.toThrow();
+    expect(repo.getSession("alice")?.branch).toBe("feat/x");
+  });
+
+  it("preserves a previously-set client_session_id when register is called again without it (COALESCE)", () => {
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      client_session_id: "uuid-aaa",
+    });
+
+    // Legacy register (e.g. heartbeat-recreate fallback) does not pass it.
+    repo.registerSession({
+      id: "alice",
+      project: "/repo",
+      branch: "feat/y",
+    });
+
+    expect(repo.getSession("alice")?.client_session_id).toBe("uuid-aaa");
+    expect(repo.getSession("alice")?.branch).toBe("feat/y");
+  });
+});
+
+describe("client_session_id mapping — CLI resolve-session", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let env: Record<string, string>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "claude-presence-resolve-"));
+    dbPath = join(tmpDir, "state.db");
+    env = { CLAUDE_PRESENCE_DB: dbPath };
+    const db = openDatabase(dbPath);
+    const repo = new Repository(db);
+    repo.registerSession({
+      id: "alice",
+      project: "/myproj",
+      branch: "main",
+      client_session_id: "claude-uuid-alice",
+    });
+    repo.registerSession({
+      id: "alice-other-project",
+      project: "/other",
+      client_session_id: "claude-uuid-other",
+    });
+    db.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("emits {session_id} when the client id is mapped", () => {
+    const out = runCli(env, [
+      "resolve-session",
+      "--client",
+      "claude-uuid-alice",
+      "--json",
+    ]) as { session_id: string; project: string; branch: string };
+    expect(out.session_id).toBe("alice");
+    expect(out.project).toBe("/myproj");
+    expect(out.branch).toBe("main");
+  });
+
+  it("emits {session_id: null} when nothing is mapped", () => {
+    const out = runCli(env, [
+      "resolve-session",
+      "--client",
+      "unknown-uuid",
+      "--json",
+    ]);
+    expect(out).toEqual({ session_id: null });
+  });
+
+  it("scopes by --project when provided", () => {
+    const matching = runCli(env, [
+      "resolve-session",
+      "--client",
+      "claude-uuid-alice",
+      "--project",
+      "/myproj",
+      "--json",
+    ]) as { session_id: string };
+    expect(matching.session_id).toBe("alice");
+
+    const mismatch = runCli(env, [
+      "resolve-session",
+      "--client",
+      "claude-uuid-alice",
+      "--project",
+      "/wrong-project",
+      "--json",
+    ]);
+    expect(mismatch).toEqual({ session_id: null });
+  });
+});
+
+describe("client_session_id mapping — migration from older schema", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "claude-presence-mig-cs-"));
+    dbPath = join(tmpDir, "state.db");
+
+    // Seed a sessions table WITHOUT client_session_id (pre-feature schema).
+    const seed = new Database(dbPath);
+    seed.exec(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        branch TEXT,
+        intent TEXT,
+        pid INTEGER,
+        hostname TEXT,
+        started_at INTEGER NOT NULL,
+        last_heartbeat INTEGER NOT NULL,
+        metadata TEXT
+      );
+    `);
+    seed.prepare(
+      "INSERT INTO sessions (id, project, started_at, last_heartbeat) VALUES (?, ?, ?, ?)",
+    ).run("legacy", "/legacy-proj", Date.now(), Date.now());
+    seed.close();
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("adds the client_session_id column without throwing", () => {
+    const db = openDatabase(dbPath);
+    const cols = db
+      .prepare("PRAGMA table_info(sessions)")
+      .all() as Array<{ name: string }>;
+    expect(cols.map((c) => c.name)).toContain("client_session_id");
+    db.close();
+  });
+
+  it("creates idx_sessions_client_id after the column is added", () => {
+    const db = openDatabase(dbPath);
+    const indexes = db
+      .prepare("PRAGMA index_list(sessions)")
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((i) => i.name)).toContain("idx_sessions_client_id");
+    db.close();
+  });
+
+  it("preserves the pre-existing row with client_session_id = null", () => {
+    const db = openDatabase(dbPath);
+    const repo = new Repository(db);
+    const row = repo.getSession("legacy");
+    expect(row?.id).toBe("legacy");
+    expect(row?.client_session_id).toBeNull();
+    db.close();
+  });
+
+  it("is idempotent — opening twice does not duplicate columns", () => {
+    openDatabase(dbPath).close();
+    const db = openDatabase(dbPath);
+    const cols = db
+      .prepare("PRAGMA table_info(sessions)")
+      .all() as Array<{ name: string }>;
+    expect(cols.filter((c) => c.name === "client_session_id")).toHaveLength(1);
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

Real bug from production: two sessions registered via \`/register\` post DMs and \`urgent\` broadcasts to each other, but the recipient never sees them in the next prompt — auto-surfacing was silently broken.

**Root cause**: the \`UserPromptSubmit\` hook receives Claude Code's internal session id on stdin, which is **not** the human-friendly id stored in the DB at \`/register\` time. The hook was searching by the wrong key and finding nothing.

**Fix**: add a mapping from the host's session id to the claude-presence session id, propagated by the \`/register\` slash command via \`\${CLAUDE_SESSION_ID}\`. The hook resolves the mapping on every prompt, then proceeds as before.

## Changes

- **DB**: new column \`sessions.client_session_id\` (TEXT, nullable, indexed). Migration in-place for legacy DBs via \`migrateSessions()\`. The column is added to \`CREATE TABLE sessions\` in \`SCHEMA_SQL\` but the index is created **only** in the migration (lesson from PR #21 — never reference a migrated column in an index inside \`SCHEMA_SQL\`).
- **Repository**: \`registerSession\` accepts \`client_session_id\` and throws \`ClientSessionConflictError\` if a different session tries to reclaim it. \`ON CONFLICT DO UPDATE\` uses \`COALESCE\` so a legacy re-register without the field does not nullify a previously-set mapping. New method \`findByClientSessionId(client_id, project?)\`.
- **MCP tool \`session_register\`**: accepts the field, catches the conflict error and returns \`{ok: false, reason: \"client_session_id_conflict\", held_by, advice}\`.
- **CLI**: new subcommand \`claude-presence resolve-session --client <id> [--project <path>] [--json]\`. Returns \`{session_id, project, branch}\` if mapped, \`{session_id: null}\` otherwise.
- **Slash command \`/register\`**: instructed to pass \`\${CLAUDE_SESSION_ID}\` as \`client_session_id\`.
- **Hook \`user-prompt-submit.sh\`**: resolves the stdin session id to the claude-presence session id via the new CLI subcommand. Uses the resolved id for \`refresh-branch\`, \`inbox\` peek, and presence counting. Falls back gracefully (generic counter, no verbatim injection) for sessions without a mapping.
- **Docs**: feature bullet in both READMEs + new \"How identity resolution works\" subsection in the Hooks section.

## Test plan

- [x] \`npm test\` — **104/104** green locally (was 90, +14 dedicated tests in \`tests/client-session-mapping.test.ts\` covering store/retrieve, scope filter, conflict, idempotent re-register, COALESCE preservation, CLI JSON contract, migration from pre-feature schema, index creation, idempotent re-open)
- [x] End-to-end smoke test: register Alice with \`client_session_id=claude-uuid-alice\`, post an \`urgent\` DM from Bob → Alice, run the hook with \`session_id=claude-uuid-alice\` on stdin → \`additionalContext\` contains the verbatim DM. Exactly the behaviour that was missing.
- [x] Conflict path tested (\`ClientSessionConflictError\` thrown, structured MCP response)
- [x] Graceful degradation: hook with an unmapped \`session_id\` produces the generic counter without errors
- [ ] CI green on Ubuntu + macOS × Node 20/22/24 (6 jobs)

## Notes

- This branch is based on main pre-PR #22 (better-sqlite3 v12 bump). It will rebase cleanly after #22 merges — different files.
- The MCP tool description and a comment in the hook reference \`\${CLAUDE_SESSION_ID}\` by name. That's an env-var name and an external runtime contract, not a signature or attribution.