### PR TITLE
chore: bump to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-presence",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Minimal MCP server for inter-session coordination between parallel Claude Code instances: presence registry, resource locks, broadcast inbox.",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Repository } from "./db/repository.js";
 import { registerAllTools } from "./tools/registry.js";
 
 const PACKAGE_NAME = "claude-presence";
-const PACKAGE_VERSION = "0.2.1";
+const PACKAGE_VERSION = "0.2.2";
 
 const SERVER_INSTRUCTIONS = `
 This server coordinates multiple Claude Code sessions running in parallel on the same machine.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,7 +11,7 @@ import { handleHealth } from "./health.js";
 import { log } from "./logger.js";
 
 const PACKAGE_NAME = "claude-presence";
-const PACKAGE_VERSION = "0.2.1";
+const PACKAGE_VERSION = "0.2.2";
 
 const DEFAULT_PORT = 3471;
 const DEFAULT_HOST = "127.0.0.1";


### PR DESCRIPTION
Pre-release version bump.

Aggregates 6 PRs since v0.2.1:

- #18 fix: TTL session 7d → 24h
- #19 feat: targeted notifications + priority + auto-surfacing
- #20 feat: auto-refresh branch on git checkout (closes #13)
- #21 fix: migration index order (regression from #19)
- #22 chore: bump better-sqlite3 v12 + drop Node 18 from CI
- #23 feat: client_session_id mapping for hook-based notification surfacing

## Test plan

- [x] `npm test` — 104/104 green locally
- [x] `npm run build` clean
- [ ] CI green on Ubuntu + macOS × Node 20/22/24 (6 jobs)