### PR TITLE
fix: emit systemMessage so notifications are visible to the user

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -82,7 +82,7 @@ C'est toute la boucle. Tout le reste ci-dessous, c'est du détail.
 - **Zéro démon (mode stdio)** — adossé à SQLite, sans port, sans processus en arrière-plan pour l'usage solo / mono-machine
 - **Mode équipe (v0.2+)** — serveur HTTP auto-hébergé optionnel avec auth bearer-token et RBAC pour coordonner plusieurs machines
 - **Rafraîchissement auto de la branche** — quand l'utilisateur fait `git checkout`, la branche stockée est mise à jour silencieusement au prompt suivant
-- **Notifications auto-surfacées** — les messages directs (`/notify`) et les broadcasts `warning`/`urgent` apparaissent automatiquement au prochain prompt de la session destinataire, sans avoir besoin de taper `/inbox`
+- **Notifications auto-surfacées** — tout message non lu adressé à ta session (DM ou broadcast, toutes priorités) est annoncé visuellement par une bannière `🔔 claude-presence: N unread message(s)` au-dessus de la réponse suivante, et le contenu complet est passé au modèle pour qu'il puisse répondre précisément si tu lui poses la question. Sans avoir à taper `/inbox`.
 - **Nettoyage par TTL** — les sessions sans heartbeat depuis 24 heures sont purgées automatiquement
 
 ## Installation
@@ -225,15 +225,19 @@ La session B peut maintenant poursuivre.
 Les commandes slash couvrent 99% de l'usage quotidien. Les hooks sont du polissage optionnel pour le dernier 1% :
 
 - **`hooks/session-start.sh`** s'exécute à l'ouverture d'une nouvelle session Claude Code. Il affiche un rappel court pour que tu penses à `/register` et aux verrous de ressources avant les opérations partagées. Il **n'enregistre pas** la session automatiquement (c'est voulu — la commande slash garde l'enregistrement explicite).
-- **`hooks/user-prompt-submit.sh`** s'exécute à chaque prompt utilisateur. Il injecte un message système d'une ligne dans le contexte quand d'autres sessions ou verrous sont actifs sur ce projet, et fait remonter les messages directs et les broadcasts `warning`/`urgent` mot pour mot pour que la session destinataire les voie à son prochain prompt sans avoir besoin de taper `/inbox`.
+- **`hooks/user-prompt-submit.sh`** s'exécute à chaque prompt utilisateur. Quand quelque chose est en attente sur ce projet, il émet deux sorties :
+  - un `systemMessage` affiché **visiblement au-dessus de la réponse du modèle** (`🔔 claude-presence: N unread message(s) — see below`), pour que l'utilisateur ne puisse pas le rater ;
+  - un `additionalContext` passé silencieusement au modèle avec l'inbox complet non lu (DM + broadcasts, toutes priorités) et le récap présence/locks, pour que le modèle puisse répondre précisément si tu demandes "j'ai des notifications ?".
+
+  Les messages sont lus en `peek` — ils restent non lus pour `/inbox`.
 
 > Le hook `UserPromptSubmit` appelle la CLI `claude-presence`, donc elle doit être dans ton `PATH` (géré par `npm link` ou `npm install -g`). Si la CLI est absente, le hook sort silencieusement avec 0 — pas de blocage.
 
 ### Comment marche la résolution d'identité
 
-Le hook reçoit l'id de session interne de Claude Code sur stdin, qui **n'est pas** le même que l'id humain que tu choisis au moment de `/register`. La commande slash `/register` stocke donc les deux : à l'invocation elle passe `${CLAUDE_SESSION_ID}` comme `client_session_id`, créant un mapping entre l'id client et celui que tu as choisi. À chaque prompt, le hook appelle `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` pour identifier "moi" et trouver les DM et broadcasts haute-priorité qui m'étaient adressés.
+Le hook reçoit l'id de session interne de Claude Code sur stdin, qui **n'est pas** le même que l'id humain que tu choisis au moment de `/register`. La commande slash `/register` stocke donc les deux : à l'invocation elle passe `${CLAUDE_SESSION_ID}` comme `client_session_id`, créant un mapping entre l'id client et celui que tu as choisi. À chaque prompt, le hook appelle `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` pour identifier "moi" et lister tous les messages non lus adressés à cette session.
 
-Si aucun mapping n'existe (sessions héritées d'avant cette feature, ou `client_session_id` volontairement omis), le hook dégrade proprement : il affiche toujours le compteur générique (`N autres sessions actives, M non lus`), mais ne peut pas injecter les notifications verbatim.
+Si aucun mapping n'existe (sessions héritées d'avant cette feature, ou `client_session_id` volontairement omis), le hook dégrade proprement : il émet toujours un compteur générique (`N autres sessions actives`) dans `additionalContext`, mais ne peut pas afficher la bannière `🔔` ni injecter les notifications verbatim.
 
 ### Activation
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ That's the whole loop. Everything below is detail.
 - **Zero daemon (stdio mode)** — SQLite-backed, no port, no background process for solo / single-machine use
 - **Team mode (v0.2+)** — optional self-hosted HTTP server with bearer-token auth and RBAC for coordination across machines
 - **Auto branch refresh** — when the user runs `git checkout`, the session's stored branch is updated transparently on the next prompt
-- **Auto-surfaced notifications** — direct messages (`/notify`) and `warning`/`urgent` broadcasts appear in the recipient session's next prompt automatically, no manual `/inbox` needed
+- **Auto-surfaced notifications** — any unread message addressed to your session (DM or broadcast, all priorities) is announced visually with a `🔔 claude-presence: N unread message(s)` banner above the next reply, plus the full content is passed to the model so it can answer accurately if you ask about it. No manual `/inbox` needed.
 - **TTL-based cleanup** — sessions with no heartbeat for 24 hours are removed automatically
 
 ## Install
@@ -225,15 +225,19 @@ Session B can now proceed.
 The slash commands cover 99% of daily use. Hooks are optional polish for the last 1%:
 
 - **`hooks/session-start.sh`** runs when you open a new Claude Code session. It prints a short reminder so you remember to `/register` and think about resource locks before shared ops. It does **not** auto-register the session (by design — the slash command keeps it explicit).
-- **`hooks/user-prompt-submit.sh`** runs on every user prompt. It injects a one-line system message into the context when other sessions or locks are active on this project, and surfaces direct messages and `warning`/`urgent` broadcasts verbatim so the recipient sees them on its next prompt without typing `/inbox`.
+- **`hooks/user-prompt-submit.sh`** runs on every user prompt. It emits two things when something is pending on this project:
+  - a `systemMessage` shown **visibly above the model's reply** (`🔔 claude-presence: N unread message(s) — see below`), so the user can't miss it;
+  - an `additionalContext` payload passed silently to the model with the full unread inbox (DMs + broadcasts, all priorities) + presence/locks summary, so the model can answer accurately if you ask "what notifications do I have?".
+
+  Messages are read in `peek` mode — they stay unread for `/inbox`.
 
 > The `UserPromptSubmit` hook shells out to the `claude-presence` CLI, so it must be on your `PATH` (handled by `npm link` or `npm install -g`). If the CLI is missing, the hook silently exits 0 — no breakage.
 
 ### How identity resolution works
 
-The hook receives Claude Code's internal session id on stdin, which is **not** the same as the human-friendly id you choose at `/register`. The `/register` slash command therefore stores both: when invoked, it passes `${CLAUDE_SESSION_ID}` as `client_session_id`, building a mapping from the client id to your chosen one. On every prompt, the hook calls `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` to find "me" and look up DMs and high-priority broadcasts addressed to that session id.
+The hook receives Claude Code's internal session id on stdin, which is **not** the same as the human-friendly id you choose at `/register`. The `/register` slash command therefore stores both: when invoked, it passes `${CLAUDE_SESSION_ID}` as `client_session_id`, building a mapping from the client id to your chosen one. On every prompt, the hook calls `claude-presence resolve-session --client <CLAUDE_SESSION_ID>` to find "me" and look up every unread message addressed to that session id.
 
-If no mapping exists (legacy sessions registered before this feature, or `client_session_id` omitted on purpose), the hook degrades gracefully: it still shows the generic counter (`N other sessions active, M unread`), but cannot inject verbatim notifications.
+If no mapping exists (legacy sessions registered before this feature, or `client_session_id` omitted on purpose), the hook degrades gracefully: it still emits a generic counter in `additionalContext` (`N other sessions active`), but cannot show the `🔔` banner or inject verbatim notifications.
 
 ### Enable them
 

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # claude-presence — UserPromptSubmit hook
 #
-# Surfaces unread inbox messages and a one-line presence summary on each prompt.
-# Direct messages (to_session = me) and warning/urgent broadcasts are injected
-# verbatim. Lower-priority broadcasts only contribute to the counter.
+# Emits two outputs per prompt:
+#   - systemMessage: short banner visible to the user above the model's reply
+#     ("🔔 claude-presence: N unread message(s) — see below"). Shown only
+#     when something pending exists (DM or broadcast, any priority).
+#   - hookSpecificOutput.additionalContext: full unread inbox + presence
+#     summary, passed silently to the model so it can answer accurately
+#     if the user asks about pending notifications. Read in peek mode,
+#     so messages stay unread for /inbox.
 #
 # Runs on every user prompt, so it MUST be fast (< 100ms).
 
@@ -65,8 +70,8 @@ if [ -n "${PRESENCE_SESSION_ID:-}" ]; then
   INBOX_COUNT="$(printf '%s' "$INBOX_JSON" | sed -n 's/.*"unread_total"[[:space:]]*:[[:space:]]*\([0-9]*\).*/\1/p' | head -n 1)"
   INBOX_COUNT="${INBOX_COUNT:-0}"
 
-  # Surface DMs and warning/urgent broadcasts as full text (not just a counter).
-  HIGH_JSON="$(claude-presence inbox --project "$CWD" --session "$PRESENCE_SESSION_ID" --peek --min-priority warning --json 2>/dev/null || echo '{}')"
+  # Surface every unread message (DMs + broadcasts, all priorities).
+  HIGH_JSON="$(claude-presence inbox --project "$CWD" --session "$PRESENCE_SESSION_ID" --peek --json 2>/dev/null || echo '{}')"
   if printf '%s' "$HIGH_JSON" | grep -q '"messages"'; then
     INBOX_TEXT="$(node -e '
       let s = "";
@@ -110,6 +115,17 @@ if [ "${INBOX_COUNT:-0}" -gt 0 ]; then
 fi
 SUMMARY="${SUMMARY}."
 
+# systemMessage: short, user-visible banner (printed in the terminal above
+# the model's reply). Shown whenever there is at least one unread message
+# addressed to this session, regardless of priority. Omitted otherwise so
+# we don't spam when the inbox is empty.
+SYSTEM_MSG=""
+if [ -n "$INBOX_TEXT" ]; then
+  SYSTEM_MSG="🔔 claude-presence: ${INBOX_COUNT} unread message(s) — see below"
+fi
+
+# additionalContext: full detail passed silently to the model so it can
+# answer accurately if the user asks about pending notifications.
 if [ -n "$INBOX_TEXT" ]; then
   CONTEXT="${SUMMARY}
 
@@ -119,15 +135,35 @@ else
   CONTEXT="${SUMMARY} Call session_list, resource_list, or read_inbox for details before shared operations."
 fi
 
-# JSON-escape the context payload.
-ESCAPED="$(printf '%s' "$CONTEXT" | node -e '
+# JSON-escape both payloads.
+ESCAPED_CONTEXT="$(printf '%s' "$CONTEXT" | node -e '
+  let s = "";
+  process.stdin.on("data", (d) => (s += d));
+  process.stdin.on("end", () => process.stdout.write(JSON.stringify(s)));
+')"
+ESCAPED_SYS="$(printf '%s' "$SYSTEM_MSG" | node -e '
   let s = "";
   process.stdin.on("data", (d) => (s += d));
   process.stdin.on("end", () => process.stdout.write(JSON.stringify(s)));
 ')"
 
-cat <<EOF
+if [ -n "$SYSTEM_MSG" ]; then
+  cat <<EOF
 {
-  "additionalContext": ${ESCAPED}
+  "systemMessage": ${ESCAPED_SYS},
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": ${ESCAPED_CONTEXT}
+  }
 }
 EOF
+else
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": ${ESCAPED_CONTEXT}
+  }
+}
+EOF
+fi


### PR DESCRIPTION
## Summary

v0.2.2 advertised "auto-surfaced notifications" but the feature only worked half: the hook emitted `additionalContext` (model-only, invisible to user), so when the user typed any prompt with pending DMs, they saw nothing on screen. The model knew about the messages but only mentioned them if the user explicitly asked.

This PR fixes the visible part.

## Fix

- **`hooks/user-prompt-submit.sh`** emits the two-output form documented at `code.claude.com/docs/en/hooks.md`:
  - top-level `systemMessage`: short banner printed above the model's reply (`🔔 claude-presence: N unread message(s) — see below`)
  - `hookSpecificOutput.additionalContext` (new modern form, was previously top-level `additionalContext`): full unread inbox + presence summary, silently passed to the model
- **Drop the `--min-priority warning` filter** so `info`-priority messages also count and appear in the banner.
- Graceful degradation preserved: when no `client_session_id` mapping exists, the hook falls back to `additionalContext`-only with a generic counter (no banner).
- Header docstring rewritten to match the new behavior.

## Docs

- `README.md` + `README.fr.md`: Features bullet and Hooks section rewritten to mention the `🔔` banner, the two-output split, and the all-priority surfacing.

## Test plan

- [x] Live test in a real Claude Code session: user typed "test", saw `UserPromptSubmit says: 🔔 claude-presence: 1 unread message(s) — see below` printed above the model's reply.
- [x] Live test with both `warning` and `info` messages pending: banner counts both (`2 unread message(s)`), both appear in `additionalContext`.
- [x] `npm test` — 104/104 green (no source code changed, hook is shell with no unit-test coverage in this repo by convention).
- [x] `grep` for forbidden mentions — clean.
- [ ] CI green on Ubuntu + macOS × Node 20/22/24 (6 jobs)

## Notes

- This is the kind of bug that should ship in **v0.2.3** because v0.2.2's marquee feature is materially incomplete without it.